### PR TITLE
Update CPT Dropout Data Visualization 3-5-18.Rmd

### DIFF
--- a/data_script/CPT Dropout Data Visualization 3-5-18.Rmd
+++ b/data_script/CPT Dropout Data Visualization 3-5-18.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(echo = TRUE)
 rm(list=ls()) 
 
 #set working directory
-setwd("//vhapalmpncptsd1/Shared Research/TeamPSD/R")
+setwd("set this to your working directory")
 
 #check working directory
 getwd()
@@ -30,8 +30,8 @@ library(dplyr)
 library(psych)
 
 #set up both files as dataframes
-comparator.df <-read.csv(file="comparatorsites_nov23_16.csv", header=TRUE) 
-dropout.df <- read.csv(file="dropout.csv",header=TRUE) 
+comparator.df <-read.csv(file="insert name of file number one.csv", header=TRUE) 
+dropout.df <- read.csv(file="insert name of file number two.csv",header=TRUE) 
 
 #set all variable names as lower case
 names(comparator.df) <- tolower(names(comparator.df))

--- a/data_script/CPT Dropout Data Visualization 3-5-18.Rmd
+++ b/data_script/CPT Dropout Data Visualization 3-5-18.Rmd
@@ -345,4 +345,4 @@ CPT appointments
 
 plot(encountersub.df$quarteryear, encountersub.df$cpt_initial_appoints, col='blue')
 ```
-##I am not that clear on how to interpret this box/whisker plot at the moment with the data prior to 2014Q3 so 
+##I am not that clear on how to interpret this box/whisker plot at the moment with the data prior to 2014Q3 so I will pause here to resume tomorrow.


### PR DESCRIPTION
*It is unclear to me why the plots that are visible when I knit the RMD file into html are not present in this RMD file
This is an RMD file of CPT Dropout and CDW Data Visualizations. I created a new file in the datascripts branch of the master as this is a new set of code in RMD form that I have been generating holding the 3 principles of coding in mind in order to be as transparent and reproducible as possible in my workflow: a) I tried to make it as human readable as possible, following an order, attempting to put assignment and transformation together, and trying to make sure nothing is hidden; b) I also tried to construct my script to make sure that everything needed for someone else to use it is ideally visible: specifically noted that a YAML header is present, my working directory/importing code is visible, my transforming and assigning is present (although I intentionally have put the numeric coaxing below my generation ofa  new merged dataframe. I wanted to think about it as creating my data source first and hten manipulating the datasource, rather than manipulating it prior to creating the data source - I welcome further discussion on this), as well as descriptives/visualization. As you will see, I generally did not get to the Analyses yet; c) I also attempted to annotate my rationale and description extensively.