### PR TITLE
Create comparatorclinics

### DIFF
--- a/comparatorclinics
+++ b/comparatorclinics
@@ -1,0 +1,118 @@
+---
+title: "Selecting CDW Dataset for clinics and not observations"
+author: "Joyce Yang"
+date: "August 3, 2018"
+output:
+  html_document:
+    df_print: paged
+  pdf_document: default
+  word_document: default
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+#knitr::opts_knit$set(root.dir = normalizePath("//vhapalmpncptsd1/Shared Research/TeamPSD/quant_workgroup/r"))
+```
+
+
+
+## Setting up the R environment and datasets
+```{r, include=FALSE}
+library(readxl)
+library(magrittr)
+library(lubridate)
+library(dplyr)
+library(psych)
+```
+
+
+```{r, include=FALSE}
+#set up both files as dataframes
+comparator.df <- read.csv("Original Data/comparatorsites_nov23_16.csv", header=TRUE) 
+dropout.df <- read.csv(file="Original Data/dropout.csv",header=TRUE) 
+
+#set all variable names as lower case
+names(comparator.df) <- tolower(names(comparator.df))
+
+names(dropout.df) <- tolower(names(dropout.df))
+
+variable.names(comparator.df)
+variable.names(dropout.df)
+
+```
+
+
+## Setup the CDW Comparator Data part 1
+
+```{r numeric, include=TRUE}
+##Set variables as numeric in order to manipulate later
+#set up in original CDW 
+##create combined variable in comparator.df based on the variable 'year' and the variable 'quarter'
+
+comparator.df <- comparator.df %>%
+  mutate_at(vars(totalencounters:x._cbt_sud_sessions), as.numeric) %>%
+  mutate(year_q  = paste0(year, "-", quarter), 
+         site_yq = paste0(sta6a,"-",year_q))
+
+```
+
+##create combined variable in dropout.df; note that quarters in comparator are fiscal year quarters with Oct 1 start
+
+```{r}
+dropout.df <- dropout.df %>% 
+  mutate(date_1 = as.character(date_1),
+         date_1 = as.Date(date_1, "%m/%d/%Y"),
+         year = year(date_1), 
+         quarter = quarter(date_1, with_year = FALSE, fiscal_start = 10),
+         quarter = paste0("Q", quarter),
+         year_q = paste0(year, "-", quarter),
+         site_yq = paste0(sta6a,"-",year_q)) 
+
+table(dropout.df$year, useNA = 'ifany')
+  ## Where are there 3 obs whose year is beyond 2016?
+  ## About 40% of the data doesn't have any year record. Will this impact the analysis?
+  ## Note that the  year available in the dropout data only overlaps with part of the  year in the comparator data. Is that okay?
+
+
+```
+
+
+##NEW CODE
+## Setup the CDW Comparator Data part 2
+## Select CDW for dates that match the CPT database, which is from May 9, 2012 - December 2, 2016.  CDW data ranges from 2011Q4 until 2016Q3. Overlap is from 2012Q2 until 2016Q3 (although that does not fully cover CPT dates, since CPT goes to 2016Q4. What do we do about this?)
+## Must select for CDW only from 2012Q2 to 2016Q3
+
+##select the subset of comparator that we want to work with: here we are selecting for all quarters except for Q5 (i.e., Q1-4), as well as selecting for when the level of the data is read at sta6a (i.e., not examining data read in at the sta3n level) and when the stopcodes are ALL (i.e., not examining data broken down to stopcodes of SUD and PTSD)
+```{r}
+
+compsub.df <- comparator.df %>%
+  filter(year_q == 2012Q2:2016Q3) %>%
+  filter(quarter != "Q5") %>%
+  filter(level == "sta6a") %>%
+  filter(stopcode == "ALL") %>% 
+select(level, stopcode, quarter, year, quarteryear, sta6a, totalencounters, patientpanel, providerpanel, psychiatrists, psychologists, socialworkers, nursepractitioners, evalencounter, psychencounter, ptsd_ebpsyeligible, pe_initial_appoints, cpt_initial_appoints, site_yq, sta6acomplexity, tmh, psychmmencounter, groupencounter, mmencounter, casemanagement, telephoneencounter, otherencounter, depression_ebpsyeligible, cbt_d_initial_appoints, act_initial_appoints, ipt_initial_appoints)
+  
+```
+##create new dataframe that merges the two datasets on the site_yq variable
+```{r}
+merge.df <- merge.data.frame(compsub.df, dropout.df, by = "site_yq")
+summary (merge.df)
+```
+
+
+## Make sure that we are looking at number of clinics and not number of observations, analyses should be based on unique number of sta6a and sta3n combinations versus observations
+
+## Generate concatenated variable: sta6asta3n.
+
+```{r}
+compsub.df <- compsub.df %>%
+   mutate(sta6asta3n = paste0(sta6a,sta3n)
+```
+
+##Generate another dataframe that is the comparator.df minus the selection that was merged (with the CPT dataset), in order to compare the CPT sites with other sites (i.e., CDW minus CPT; compare X with 1 - X)
+
+```{r}
+cdw_minus_merge.df <- anti_join(compsub.df, dropout.df, by= "site_yq")
+
+```
+


### PR DESCRIPTION
Hi Savet,

Thank you for reviewing this code for me. I used most of the same code that you already cleaned and reviewed for me for the anti_join code.  In order to make sure that the CDW_minus_merge data we are looking at is only the data with dates that match the CPT dataset, I entered the following based on the timeframe, so the new code starts at Line 80:  filter(year_q == 2012Q2:2016Q3) %>%

For the second issue of making sure that we are looking at number of clinics and not number of observations, I believe I should be doing the analyses based on unique number of sta6a and sta3n combinations versus observations. To do this, I'm trying to generate a concatenated variable sta6asta3n. When I examine the frequencies of this I can tell the unique number of combinations. Is that the right way to think about this? 

Additionally however, I'm not very clear on how to run subsequent descriptors of other variables (e.g., total encounters) that is not a mean of each observation of total encounters, but instead is a mean of total encounters based on unique combinations of sta6a & sta3ns (i.e., clinics). i.e., I believe I still cannot do describe(cdw_minus_merge.df$totalencounters) for example, because that will still give me descriptive statistics on totalencounters based on observations and not unique sta6asta3n combinations. Can you please help me with this code?

Thank you!