### PR TITLE
Standardized version of PSY

### DIFF
--- a/model_workgroup/models/psy_v18_2018_06_21_uifreeze.mdl
+++ b/model_workgroup/models/psy_v18_2018_06_21_uifreeze.mdl
@@ -1,91 +1,91 @@
-{UTF-8}
-"From8PL-PL3mo into Low D"=
-	"Continuing Treatment Rate (After 3 Months) from Over 7 Visits"*"PL3mo % starting LowD"
-	~	pt/Week
+From Completers into Low D=
+	"Continuing Treatment Rate (After 3 Months) from Over 7 Visits"*"Starting LowD %"
+	~	pts/wk
 	~	The starting rate of one quarter of patients who (after completing 8 or \
 		more visits in their first 3 months) complete more visits in the \
 		subsequent months.
 	|
 
-"From8PL-PL3mo into Mid D"=
-	"Continuing Treatment Rate (After 3 Months) from Over 7 Visits"*"PL3mo % starting MidD"
-	~	pt/Week
+From Completers into Mid D=
+	"Continuing Treatment Rate (After 3 Months) from Over 7 Visits"*"Starting MidD %"
+	~	pts/wk
 	~	The starting rate of two quarters of patients who (after completing 8 or \
 		more visits in their first 3 months) complete more visits in the \
 		subsequent months.
 	|
 
 Ending After 1 Visit Rate=
-	"% One-n-Dones"*Ending 1
-	~	pt/Week
+	"% One-n-Dones"*Ending First Visit
+	~	pts/wk
 	~		~	:SUPPLEMENTARY 
 	|
 
-"From8PL-PL3mo into High D"=
-	"Continuing Treatment Rate (After 3 Months) from Over 7 Visits"*"PL3mo % starting HighD"
-	~	pt/Week
+From Completers into High D=
+	"Continuing Treatment Rate (After 3 Months) from Over 7 Visits"*"Starting HighD %"
+	~	pts/wk
 	~	The starting rate of one quarter of patients who (after completing 8 or \
 		more visits in their first 3 months) complete more visits in the \
 		subsequent months.
 	|
 
 "Continuing Treatment Rate (After 3 Months) from Over 7 Visits"=
-	Ending First 3months of Psychotherapy*(1-"%Visit8PL-n-Done")
-	~	
+	Ending After 8 or More Visits Rate*(1-"Actual Completers Who Graduate %")
+	~	pts/wk
 	~		|
 
 Initiation Rate=
-	"Starting Psychotherapy 2-7-n-Done"+"Starting Psychotherapy 2-7-n-More<3mo"+"Starting Psychotherapy- 2-7-n->3mo"
-	~	pt/Week
+	Initiation Rate who will Quit+Initiation Rate who will Complete+Initation Rate who will Return
+	~	pts/wk
 	~	Output for UI - sum of all possible rate of patients starting their second \
 		visit in their first three months engaged in care.
+	~	:SUPPLEMENTARY 
 	|
 
-"<3mo Visit 2-7 -n-done"= INTEG (
-	"Starting Psychotherapy 2-7-n-Done"-Ending During Visit 2 to 7 Rate,
+Initiators who will Quit= INTEG (
+	Initiation Rate who will Quit-Ending During Visit 2 to 7 Rate,
 		0)
-	~	pt
+	~	pts
 	~	Total number of patients scheduled for their 2-7th visit in their first \
 		three months engaged in care, who will not continue psychotherapy \
 		afterward.
 	|
 
 Patients in First Visit= INTEG (
-	Starting Rate-Ending 1,
+	Starting Rate-Ending First Visit,
 		0)
-	~	pt
+	~	pts
 	~	Total number of patients scheduled for their first visit.
 	|
 
 Patients in Over 7 Visits= INTEG (
-	"Starting Psychotherapy- 8PL"-Ending First 3months of Psychotherapy,
+	Starting Visit 8-Ending After 8 or More Visits Rate,
 		0)
-	~	pt
+	~	pts
 	~	Total number of patients scheduled for their 8th or greater visit in their \
 		first three months engaged in care.
 	|
 
 "<3mo Visit 1 who can start 2"= INTEG (
-	Starting 1 who can start 2-Ending 1 who go on,
+	Starting Rate who can Initiate-Ending who can Initiate,
 		0)
-	~	pt
+	~	pts
 	~	Total number of patients scheduled for their first visit where there is \
 		capacity for them to continue care.
 	|
 
-"<3mo Visit 2-7-n-More>3mo"= INTEG (
-	"Starting Psychotherapy- 2-7-n->3mo"-"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"\
+Initiators who will Return= INTEG (
+	Initation Rate who will Return-"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"\
 		,
 		0)
-	~	pt
+	~	pts
 	~	Total number of patients scheduled for their 2-7th visit in their first \
 		three months engaged in care, who will continue psychotherapy afterward.
 	|
 
-"<3mo Visit 2-7-n-More<3mo"= INTEG (
-	"Starting Psychotherapy 2-7-n-More<3mo"-Completion Rate,
+Initiators who will Continue= INTEG (
+	Initiation Rate who will Complete-Continuting on to Visit 8 Rate,
 		0)
-	~	pt
+	~	pts
 	~	Total number of patients scheduled for their 2-7th visit in their first \
 		three months engaged in care, who will go on to complete 8 or more visits \
 		in this period.
@@ -93,7 +93,7 @@ Patients in Over 7 Visits= INTEG (
 
 Total Pts at Initial Time=
 	SAMPLE IF TRUE(Time=0, Total Pts in Psych, :NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort just before experiments begin
 	|
@@ -101,14 +101,14 @@ Total Pts at Initial Time=
 "Exp-SankeyScalar"=
 	IF THEN ELSE(Time=FINAL TIME, (1+Percent Change in Total Patients)*SankeyScalar,:NA:\
 		)
-	~	pt
+	~	pts
 	~	The total patients in care, 2 years after starting any experiments, based \
 		on the cohort defined by the team's data.
 	|
 
 "Exp-A"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E2*"Exp-SankeyScalar",:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -116,7 +116,7 @@ Total Pts at Initial Time=
 
 Total Pts at Final Time=
 	SAMPLE IF TRUE(Time=FINAL TIME, Total Pts in Psych, :NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort, 2 years after the start of any experiments
 	|
@@ -131,7 +131,7 @@ Percent Change in Total Patients=
 
 Completing Rate=
 	Appointments Used by Existing Patients
-	~	appt/Week
+	~	appt/wk
 	~	Total possible appointment completion rate, as determined by appointment \
 		supply.
 	~	:SUPPLEMENTARY 
@@ -140,7 +140,7 @@ Completing Rate=
 "Exp-H"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E9 * "Exp-SankeyScalar" * Sankey E2 * Sankey E7\
 		,:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -148,7 +148,7 @@ Completing Rate=
 
 "Exp-H-Bars"=
 	1+Bars E7+Bars E8+"Bars E9-Final"
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -156,8 +156,8 @@ Completing Rate=
 	|
 
 D=
-	("%Visit2-7-n-Done Data") * SankeyScalar * ("% Go on to 2-7 in <3mo Data")
-	~	pt
+	("Initiators Who Quit Early %") * SankeyScalar * ("Starters Who Initiate %")
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -165,7 +165,7 @@ D=
 
 "D-Bars"=
 	Bars E5+1
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -173,9 +173,9 @@ D=
 	|
 
 E=
-	(1-("%Visit2-7-n-Done Data" + "%Visit2-7-n-More<3mo Data")) * SankeyScalar * ("% Go on to 2-7 in <3mo Data"\
-		)
-	~	pt
+	(1-("Initiators Who Quit Early %" + "Initiators Who Complete %")) * SankeyScalar * (\
+		"Starters Who Initiate %")
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -183,7 +183,7 @@ E=
 
 "E-Bars"=
 	1+Bars E6+"Bars E6 >3mo-Initial"
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -192,7 +192,7 @@ E=
 
 "Exp-F"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E7 * "Exp-SankeyScalar" * Sankey E2,:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -200,13 +200,13 @@ E=
 
 SankeyScalar=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C37')
-	~	pt
+	~	pts
 	~	The total number of patients in the cohort defined by the team's data.
 	|
 
 B=
-	(1-("% Go on to 2-7 in <3mo Data" +"%Visit1<3mo and More Data")) * SankeyScalar
-	~	pt
+	(1-("Starters Who Initiate %" +"Starters Who Return Later %")) * SankeyScalar
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -214,7 +214,7 @@ B=
 
 "G-Bars"=
 	1+Bars E7+Bars E8
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -223,7 +223,7 @@ B=
 
 "Exp-C-Bars"=
 	"Bars E4-Final"+1
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -231,9 +231,9 @@ B=
 	|
 
 H=
-	(1-("%Visit8PL-n-Done Data")) * SankeyScalar * ("% Go on to 2-7 in <3mo Data") * ("%Visit2-7-n-More<3mo Data"\
+	(1-("Completers Who Graduate %")) * SankeyScalar * ("Starters Who Initiate %") * ("Initiators Who Complete %"\
 		)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -241,7 +241,7 @@ H=
 
 "H-Bars"=
 	1+Bars E7+Bars E8+"Bars E9-Initial"
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -250,7 +250,7 @@ H=
 
 "Exp-E-Bars"=
 	1+Bars E6+"Bars E6 >3mo-Final"
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -258,20 +258,20 @@ H=
 	|
 
 Initiators who Complete=
-	ZIDZ(1, "Frequency <3mo - 2-7Visits-n-More<3mo")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1, "Frequency <3mo - 2-7Visits-n-More<3mo")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "Exp-G"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E8 * "Exp-SankeyScalar" * Sankey E2 * Sankey E7\
 		,:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -279,7 +279,7 @@ Initiators who Complete=
 
 "Exp-B"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E3*"Exp-SankeyScalar",:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -287,23 +287,23 @@ Initiators who Complete=
 
 "Exp-C"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E4*"Exp-SankeyScalar",:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
 	|
 
 A=
-	("% Go on to 2-7 in <3mo Data") * SankeyScalar
-	~	pt
+	("Starters Who Initiate %") * SankeyScalar
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
 	|
 
 F=
-	("%Visit2-7-n-More<3mo Data") * SankeyScalar * ("% Go on to 2-7 in <3mo Data")
-	~	pt
+	("Initiators Who Complete %") * SankeyScalar * ("Starters Who Initiate %")
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -311,15 +311,15 @@ F=
 
 "Exp-E"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E6 * "Exp-SankeyScalar" * Sankey E2,:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
 	|
 
 C=
-	("%Visit1<3mo and More Data")* SankeyScalar
-	~	pt
+	("Starters Who Return Later %")* SankeyScalar
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -327,7 +327,7 @@ C=
 
 "C-Bars"=
 	"Bars E4-Initial"+1
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment for patients in the cohort who meet the criteria \
 		defining this state.
@@ -335,9 +335,9 @@ C=
 	|
 
 G=
-	("%Visit8PL-n-Done Data") * SankeyScalar * ("% Go on to 2-7 in <3mo Data") * ("%Visit2-7-n-More<3mo Data"\
+	("Completers Who Graduate %") * SankeyScalar * ("Starters Who Initiate %") * ("Initiators Who Complete %"\
 		)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the base case value for the total number of \
 		patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
@@ -345,78 +345,78 @@ G=
 
 "Exp-D"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey E5 * "Exp-SankeyScalar" * Sankey E2,:NA:)
-	~	pt
+	~	pts
 	~	For the Sankey - reporting out the experiment value for the total number \
 		of patients in the cohort who meet the criteria defining this state.
 	~	:SUPPLEMENTARY 
 	|
 
 Initiators who Quit Early=
-	ZIDZ(1, "Frequency <3mo - 2-7Visits-n-done")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1, "Frequency <3mo - 2-7Visits-n-done")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 Completers who Graduate=
-	ZIDZ(1, "Frequency <3mo - 8-12 Visits")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), which is \
+	ZIDZ(1, "Frequency <3mo - 8-12 Visits")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), which is \
 		nearly identical to the frequency of patients who complete 2-7 visits and \
 		then go on to more visits in their first three months engaged in care.
 	~	:SUPPLEMENTARY 
 	|
 
 "From 1 Visit (4th Quartile)"=
-	ZIDZ(1, "Frequency >3mo - 1Visit-HighD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1, "Frequency >3mo - 1Visit-HighD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "From 1 Visit (Mean)"=
-	ZIDZ(1, "Frequency >3mo - 1Visit-MidD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1, "Frequency >3mo - 1Visit-MidD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "From 2 to 7 Visits (Mean)"=
-	ZIDZ(1,"Frequency >3mo - 2-7Visits-MidD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1,"Frequency >3mo - 2-7Visits-MidD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "From 8 or More Visits (1st Quartile)"=
-	ZIDZ(1,"Frequency >3mo - 8-12Visits-LowD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1,"Frequency >3mo - 8-12Visits-LowD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
-Starters who Quit=
-	1 - ("% Go on to 2-7 in <3mo Data" + "%Visit1<3mo and More Data")
+"Starters who Quit %"=
+	1 - ("Starters Who Initiate %" + "Starters Who Return Later %")
 	~	Dmnl
 	~	For UI output - reporting out the percent of patients who quit after their \
 		first visit.
@@ -424,51 +424,51 @@ Starters who Quit=
 	|
 
 "From 1 Visit (1st Quartile)"=
-	ZIDZ(1, "Frequency >3mo - 1Visit-LowD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1, "Frequency >3mo - 1Visit-LowD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "From 2 to 7 Visits (1st Quartile)"=
-	ZIDZ(1,"Frequency >3mo - 2-7Visits-LowD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1,"Frequency >3mo - 2-7Visits-LowD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "From 2 to 7 Visits (4th Quartile)"=
-	ZIDZ(1,"Frequency >3mo - 2-7Visits-HighD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1,"Frequency >3mo - 2-7Visits-HighD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 "From 8 or More Visits (4th Quartile)"=
-	ZIDZ(1,"Frequency >3mo - 8-12Visits-HighD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1,"Frequency >3mo - 8-12Visits-HighD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 Initators who Return Later=
-	1 - ("%Visit2-7-n-More<3mo Data" + "%Visit2-7-n-Done Data")
+	1 - ("Initiators Who Complete %" + "Initiators Who Quit Early %")
 	~	Dmnl
 	~	For UI output - reporting out the percent of patients who (after \
 		completing 2-7 visit in their first 3 months) complete more visits in the \
@@ -477,7 +477,7 @@ Initators who Return Later=
 	|
 
 Completers who Return=
-	1 - "%Visit8PL-n-Done Data"
+	1 - "Completers Who Graduate %"
 	~	Dmnl
 	~	For UI output - reporting out the percent of patients who (after \
 		completing 8 or more visits in their first 3 months) complete more visits \
@@ -486,101 +486,101 @@ Completers who Return=
 	|
 
 "From 8 or More Visits (Mean)"=
-	ZIDZ(1,"Frequency >3mo - 8-12Visits-MidD")/Pts per Appt
-	~	Week
-	~	For UI output - The average return visit interval (in weeks), estimated \
-		from the mean of all individual patients' counts of completed appointments \
-		that meet the time criteria defining this stock and their time to complete \
-		that subset of their appointments (i.e., the date difference between their \
-		last completed appointment and their first).
+	ZIDZ(1,"Frequency >3mo - 8-12Visits-MidD")/Pts per appt
+	~	wk
+	~	For UI output - The average return visit interval (in wks), estimated from \
+		the mean of all individual patients' counts of completed appointments that \
+		meet the time criteria defining this stock and their time to complete that \
+		subset of their appointments (i.e., the date difference between their last \
+		completed appointment and their first).
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Gold Standard for PTSD=
-	EBP Silver Standard for PTSD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	EBP Silver Standard for PTSD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >7 templates who completed care in <3 months with PTSD
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Silver Standard for AUD=
-	HS Silver Standard for AUD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Silver Standard for AUD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >1 templates who initiated care in <3 months with AUD
 	|
 
 EBP Silver Standard for Depression=
-	HS Silver Standard for Depression*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Silver Standard for Depression*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >1 templates who initiated care in <3 months with \
 		depression
 	|
 
 EBP Silver Standard for OUD=
-	HS Silver Standard for OUD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Silver Standard for OUD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >1 templates who initiated care in <3 months with OUD
 	|
 
 EBP Silver Standard for PTSD=
-	HS Silver Standard for PTSD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Silver Standard for PTSD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >1 templates who initiated care in <3 months with PTSD
 	|
 
 EBP Gold Standard for Depression=
-	EBP Silver Standard for Depression*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	EBP Silver Standard for Depression*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >7 templates who completed care in <3 months with \
 		depression
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Bronze Standard for AUD=
-	HS Bronze Standard for AUD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Bronze Standard for AUD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >0 templates with an appointment in <3 months with AUD
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Bronze Standard for Depression=
-	HS Bronze Standard for Depression*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Bronze Standard for Depression*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >0 templates with an appointment in <3 months with \
 		depression
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Bronze Standard for OUD=
-	HS Bronze Standard for OUD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Bronze Standard for OUD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >0 templates with an appointment in <3 months with OUD
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Bronze Standard for PTSD=
-	HS Bronze Standard for PTSD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	HS Bronze Standard for PTSD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >0 templates with an appointment in <3 months with PTSD
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Gold Standard for AUD=
-	EBP Silver Standard for AUD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	EBP Silver Standard for AUD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >7 templates who completed care in <3 months with AUD
 	~	:SUPPLEMENTARY 
 	|
 
 EBP Gold Standard for OUD=
-	EBP Silver Standard for OUD*"% of Patients who meet the HS standard who also meet the EBP standard"
-	~	pt
+	EBP Silver Standard for OUD*"Patients with Adequate EBP Templates %"
+	~	pts
 	~	All patients with >7 templates who completed care in <3 months with OUD
 	~	:SUPPLEMENTARY 
 	|
 
 "%Visit1-n-Done"=
-	MAX(MIN(1-"% Go on to 2-7 in <3mo Data"-"%Visit1<3mo and More Data",1),0)
+	MAX(MIN(1-"Starters Who Initiate %"-"Starters Who Return Later %",1),0)
 	~	Dmnl
 	~	The percent of patients who complete only one visit in their first three \
 		months (constrained between 0 and 100%).
@@ -588,7 +588,7 @@ EBP Gold Standard for OUD=
 	|
 
 "%Visit2-7<3mo and More"=
-	MAX(MIN(1-"%Visit2-7-n-More<3mo Data"-"%Visit2-7-n-Done Data",1),0)
+	MAX(MIN(1-"Initiators Who Complete %"-"Initiators Who Quit Early %",1),0)
 	~	Dmnl
 	~	The percent of patients who go on to complete more visits, after only \
 		completing 2-7 visits in their first 3 months (constrained between 0 and \
@@ -598,7 +598,7 @@ EBP Gold Standard for OUD=
 
 "%Visit8PL-n-More"=
 	MAX(MIN(
-	1-"%Visit8PL-n-Done Data"
+	1-"Completers Who Graduate %"
 	,1),0)
 	~	Dmnl
 	~	The percent of patients who complete more visits, after completing 8 or \
@@ -606,18 +606,18 @@ EBP Gold Standard for OUD=
 	~	:SUPPLEMENTARY 
 	|
 
-"From1-PL3mo into Mid D"=
-	"Continuing Treatment Rate (After 3 Months) From First Visit"*"PL3mo % starting MidD"
-	~	pt/Week
+From Starters into Mid D=
+	"Continuing Treatment Rate (After 3 Months) From First Visit"*"Starting MidD %"
+	~	pts/wk
 	~	The starting rate of two quarters of patients who (after completing only 1 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months. The percent of patients who start a second visit is constrained \
 		between zero and one.
 	|
 
-"From1-PL3mo into High D"=
-	"Continuing Treatment Rate (After 3 Months) From First Visit"*"PL3mo % starting HighD"
-	~	pt/Week
+From Starters into High D=
+	"Continuing Treatment Rate (After 3 Months) From First Visit"*"Starting HighD %"
+	~	pts/wk
 	~	The starting rate of one quarter of patients who (after completing only 1 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months. The percent of patients who start a second visit is constrained \
@@ -625,8 +625,8 @@ EBP Gold Standard for OUD=
 	|
 
 "Continuing Treatment Rate (After 3 Months) From First Visit"=
-	Ending 1 who go on*"%Visit1<3mo and More"
-	~	pt/Week
+	Ending who can Initiate*"Actual Starters Who Return Later %"
+	~	pts/wk
 	~	The starting rate of all patients who (after completing only 1 visit in \
 		their first 3 months) complete more visits in the subsequent months. The \
 		percent of patients who start a second visit is constrained between zero \
@@ -634,15 +634,15 @@ EBP Gold Standard for OUD=
 	|
 
 Appointments in Psychotherapy=
-	Total Pts in Psych/Pts per Appt
+	Total Pts in Psych/Pts per appt
 	~	appt
 	~	Appointments in Psychotherapy
 	~	:SUPPLEMENTARY 
 	|
 
-"From1-PL3mo into Low D"=
-	"Continuing Treatment Rate (After 3 Months) From First Visit"*"PL3mo % starting LowD"
-	~	pt/Week
+From Starters into Low D=
+	"Continuing Treatment Rate (After 3 Months) From First Visit"*"Starting LowD %"
+	~	pts/wk
 	~	The starting rate of one quarter of patients who (after completing only 1 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months. The percent of patients who start a second visit is constrained \
@@ -650,26 +650,26 @@ Appointments in Psychotherapy=
 	|
 
 Ending Rate=
-	"From1-+PLmo Ending Low D"+"From1-+PLmo Ending Mid D"+"From1-PL3mo Ending High D"
+	From Starters Ending Low D+From Starters Ending Mid D+From Starters Ending High D
 	+
-	"From2-7-PL3mo Ending Low D"+"From2-7-PL3mo Ending Mid D"+"From2-7-PL3mo Ending High D"
+	From Initiators Ending Low D+From Initiators Ending Mid D+From Initiators Ending High D
 	+
-	"From8PL-PL3mo Ending Low D"+"From8PL-PL3mo Ending Mid D"+"From8PL-PL3mo Ending High D"
-	~	pt/Week
+	From Completers Ending Low D+From Completers Ending Mid D+From Completers Ending High D
+	~	pts/wk
 	~	Total ending rate of all patients who remain in care after 3 months.
 	~	:SUPPLEMENTARY 
 	|
 
 Booking Rate=
-	Additional Appt Supply for New Patients+Appointment Supply
-	~	appt/Week
+	Additional Appointments Available to New Patients+Appointment Supply
+	~	appt/wk
 	~	Total possible booking rate, as determined by total appointment supply.
 	~	:SUPPLEMENTARY 
 	|
 
 HS Silver Standard for OUD=
-	("# Total Pts <3mo w/2-7 Visits"+Patients in Over 7 Visits)*"% of Total Pts <3mo w/OUD"
-	~	pt
+	(Total Initiators+Patients in Over 7 Visits)*"OUD within 3 months %"
+	~	pts
 	~	"Health Services definition"-based middle quality standard - the number of \
 		patients with OUD who initiated psychotherapy in the past 3 months.
 	|
@@ -681,10 +681,10 @@ Sankey E6=
 	~	For the Sankey - reporting out the NORMALIZED inflow of "Initiators who \
 		Get More Later" (i.e, patient starts who complete 2-7 visits in their \
 		first 3 months but only complete more visits after their first 3 months / \
-		total inflow to all possible states after a second visit) in Week 104, \
-		thus after any experiments have altered the behavior of the system. The \
-		percent of "Initiators who Get More Later" is constrained between 0 and \
-		100%, even if user input accidentally creates a negative %).
+		total inflow to all possible states after a second visit) in wk 104, thus \
+		after any experiments have altered the behavior of the system. The percent \
+		of "Initiators who Get More Later" is constrained between 0 and 100%, even \
+		if user input accidentally creates a negative %).
 	|
 
 Sankey E7=
@@ -692,10 +692,10 @@ Sankey E7=
 	~	Dmnl
 	~	For the Sankey - reporting out the NORMALIZED inflow of "Completers" (i.e, \
 		patient starts who complete 8 or more visits in their first 3 months / \
-		total inflow to all possible states after a second visit) in Week 104, \
-		thus after any experiments have altered the behavior of the system. The \
-		percent of "Completers" is constrained between 0 and 100%, even if user \
-		input accidentally creates a negative %).
+		total inflow to all possible states after a second visit) in wk 104, thus \
+		after any experiments have altered the behavior of the system. The percent \
+		of "Completers" is constrained between 0 and 100%, even if user input \
+		accidentally creates a negative %).
 	|
 
 Sankey E8=
@@ -704,7 +704,7 @@ Sankey E8=
 	~	For the Sankey - reporting out the NORMALIZED inflow of "Graduators" (i.e, \
 		patient starts who complete 8 or more visits in their first 3 months, but \
 		will not continue after those initial 3 months / total inflow to all \
-		possible states after a seventh visit) in Week 104, thus after any \
+		possible states after a seventh visit) in wk 104, thus after any \
 		experiments have altered the behavior of the system. The percent of \
 		"Graduators" is constrained between 0 and 100%, even if user input \
 		accidentally creates a negative %).
@@ -717,59 +717,59 @@ Sankey E9=
 	~	For the Sankey - reporting out the NORMALIZED inflow of "Completers who \
 		Get More Later" (i.e, patient starts who complete 8 or more visits in \
 		their first 3 months, and continue care after those initial 3 months / \
-		total inflow to all possible states after a seventh visit) in Week 104, \
-		thus after any experiments have altered the behavior of the system. The \
-		percent of "Completers who Get More Later" is constrained between 0 and \
-		100%, even if user input accidentally creates a negative %).
+		total inflow to all possible states after a seventh visit) in wk 104, thus \
+		after any experiments have altered the behavior of the system. The percent \
+		of "Completers who Get More Later" is constrained between 0 and 100%, even \
+		if user input accidentally creates a negative %).
 	|
 
 HS Silver Standard for Depression=
-	("# Total Pts <3mo w/2-7 Visits"+Patients in Over 7 Visits)*"% of Total Pts <3mo w/Depression"
-	~	pt
+	(Total Initiators+Patients in Over 7 Visits)*"DEP within 3 months %"
+	~	pts
 	~	"Health Services definition"-based middle quality standard - the number of \
 		patients with depression who initiated psychotherapy in the past 3 months.
 	|
 
 HS Silver Standard for PTSD=
-	("# Total Pts <3mo w/2-7 Visits"+Patients in Over 7 Visits)*"% of Total Pts <3mo w/PTSD"
-	~	pt
+	(Total Initiators+Patients in Over 7 Visits)*"PTSD within 3 months %"
+	~	pts
 	~	"Health Services definition"-based middle quality standard - the number of \
 		patients with PTSD who initiated psychotherapy in the past 3 months.
 	|
 
 HS Silver Standard for AUD=
-	("# Total Pts <3mo w/2-7 Visits"+Patients in Over 7 Visits)*"% of Total Pts <3mo w/AUD"
-	~	pt
+	(Total Initiators+Patients in Over 7 Visits)*"AUD within 3 months %"
+	~	pts
 	~	"Health Services definition"-based middle quality standard - the number of \
 		patients with AUDwho initiated psychotherapy in the past 3 months.
 	|
 
 Sankey One and More Laters=
-	IF THEN ELSE(Time=FINAL TIME, "From1-PL3mo into High D"+"From1-PL3mo into Low D"+"From1-PL3mo into Mid D"\
+	IF THEN ELSE(Time=FINAL TIME, From Starters into High D+From Starters into Low D+From Starters into Mid D\
 		,:NA:)
-	~	pt/Week
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "One-and-More Later" patients \
 		(i.e, all patient starts after patients' first 3 months, of patients who \
-		completed only 1 visit in their first 3 months) in Week 104, thus after \
-		any experiments have altered the behavior of the system.
+		completed only 1 visit in their first 3 months) in wk 104, thus after any \
+		experiments have altered the behavior of the system.
 	|
 
 "Sankey One n Dones + Initiators + One n More Laters"=
 	IF THEN ELSE(Time=FINAL TIME, Sankey One and Dones+Sankey Initaitors+Sankey One and More Laters\
 		, :NA:)
-	~	pt/Week
+	~	pts/wk
 	~	For the Sankey - reporting out the total inflow to all possible states \
 		after a first visit (i.e, a patient can quit, complete more visits in \
-		their first 3 months, or complete more visits after 3 months) in Week 104, \
+		their first 3 months, or complete more visits after 3 months) in wk 104, \
 		thus after any experiments have altered the behavior of the system.
 	|
 
 Sankey Completers=
-	IF THEN ELSE(Time=FINAL TIME, "Starting Psychotherapy 2-7-n-More<3mo",:NA:)
-	~	pt/Week
+	IF THEN ELSE(Time=FINAL TIME, Initiation Rate who will Complete,:NA:)
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "Completers" (i.e, patient \
 		starts who will complete 8 or more visits in their first 3 months, \
-		regardless of what engagement pathway they follow next) in Week 104, thus \
+		regardless of what engagement pathway they follow next) in wk 104, thus \
 		after any experiments have altered the behavior of the system.
 	|
 
@@ -780,7 +780,7 @@ Sankey E2=
 	~	For the Sankey - reporting out the NORMALIZED inflow of "Initiators" (i.e, \
 		all patient starts of their second visit in their first 3 months, \
 		regardless of what engagement pathway they follow next / total inflow to \
-		all possible states after a first visit) in Week 104, thus after any \
+		all possible states after a first visit) in wk 104, thus after any \
 		experiments have altered the behavior of the system.
 	|
 
@@ -790,7 +790,7 @@ Sankey E3=
 	~	Dmnl
 	~	For the Sankey - reporting out the NORMALIZED inflow of "One-n-Dones" \
 		(i.e, patient starts who only complete one visit ever / total inflow to \
-		all possible states after a first visit) in Week 104, thus after any \
+		all possible states after a first visit) in wk 104, thus after any \
 		experiments have altered the behavior of the system. The percent of \
 		"One-n-Dones" is constrained between 0 and 100%, even if user input \
 		accidentally creates a negative %).
@@ -802,7 +802,7 @@ Sankey E4=
 	~	Dmnl
 	~	For the Sankey - reporting out the NORMALIZED inflow of "One-n-Dones" \
 		(i.e, patient starts who only complete one visit ever / total inflow to \
-		all possible states after a first visit) in Week 104, thus after any \
+		all possible states after a first visit) in wk 104, thus after any \
 		experiments have altered the behavior of the system. The percent of \
 		"One-n-Dones" is constrained between 0 and 100%, even if user input \
 		accidentally creates a negative %).
@@ -815,81 +815,81 @@ Sankey E5=
 	~	For the Sankey - reporting out the NORMALIZED inflow of "Initiators who \
 		quit" (i.e, patient starts who complete 2-7 visits in their first 3 months \
 		but do not ever receive a complete dose of Psychotherapy / total inflow to \
-		all possible states after a second visit) in Week 104, thus after any \
+		all possible states after a second visit) in wk 104, thus after any \
 		experiments have altered the behavior of the system. The percent of \
 		"Initiators who quit" is constrained between 0 and 100%, even if user \
 		input accidentally creates a negative %).
 	|
 
 Sankey Graduators=
-	IF THEN ELSE(Time=FINAL TIME, "Starting Psychotherapy 2-7-n-More<3mo"*"%Visit8PL-n-Done"\
+	IF THEN ELSE(Time=FINAL TIME, Initiation Rate who will Complete*"Actual Completers Who Graduate %"\
 		,:NA:)
-	~	pt/Week
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "Granduators" (i.e, patient \
 		starts who complete 8 or more visits in their first 3 months, but will not \
-		continue after those initial 3 months) in Week 104, thus after any \
+		continue after those initial 3 months) in wk 104, thus after any \
 		experiments have altered the behavior of the system.
 	|
 
 Sankey Initaitors=
-	IF THEN ELSE(Time=FINAL TIME, "Starting Psychotherapy 2-7-n-Done"+"Starting Psychotherapy 2-7-n-More<3mo"\
-		+"Starting Psychotherapy- 2-7-n->3mo",:NA:)
-	~	pt/Week
+	IF THEN ELSE(Time=FINAL TIME, Initiation Rate who will Quit+Initiation Rate who will Complete\
+		+Initation Rate who will Return,:NA:)
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "Initiators" (i.e, all \
 		patient starts of their second visit in their first 3 months, regardless \
-		of what engagement pathway they follow next) in Week 104, thus after any \
+		of what engagement pathway they follow next) in wk 104, thus after any \
 		experiments have altered the behavior of the system.
 	|
 
 Sankey Initiators who quit=
-	IF THEN ELSE(Time=FINAL TIME, "Starting Psychotherapy 2-7-n-Done",:NA:)
-	~	pt/Week
+	IF THEN ELSE(Time=FINAL TIME, Initiation Rate who will Quit,:NA:)
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "Initiators" who never \
 		complete more visits (i.e, patient starts who will complete 2-7 visits in \
-		their first 3 months but will not continue care afterward) in Week 104, \
-		thus after any experiments have altered the behavior of the system.
+		their first 3 months but will not continue care afterward) in wk 104, thus \
+		after any experiments have altered the behavior of the system.
 	|
 
 "% One-n-Dones"=
-	MAX(MIN((1-"%Visit1<3mo and More"-"% Go on to 2-7 in <3mo"),1),0)
+	MAX(MIN((1-"Actual Starters Who Return Later %"-"Actual Starters Who Initiate %"),1)\
+		,0)
 	~	Dmnl
 	~		|
 
 Sankey Initiators who Get More Later=
-	IF THEN ELSE(Time=FINAL TIME, "Starting Psychotherapy- 2-7-n->3mo",:NA:)
-	~	pt/Week
+	IF THEN ELSE(Time=FINAL TIME, Initation Rate who will Return,:NA:)
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "Initiators" who eventually \
 		complete more visits (i.e, all patient starts after patients' first 3 \
 		months, of patients who completed 2-7 visits in their first 3 months) in \
-		Week 104, thus after any experiments have altered the behavior of the \
-		system.
+		wk 104, thus after any experiments have altered the behavior of the system.
 	|
 
 Sankey Completers who Get More Later=
-	IF THEN ELSE(Time=FINAL TIME, "Starting Psychotherapy 2-7-n-More<3mo"*(1-"%Visit8PL-n-Done"\
+	IF THEN ELSE(Time=FINAL TIME, Initiation Rate who will Complete*(1-"Actual Completers Who Graduate %"\
 		),:NA:)
-	~	pt/Week
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "Completers" who receive even \
 		more visits (i.e, all patient starts after patients' first 3 months, of \
-		patients who completed 8 or more visits in their first 3 months) in Week \
+		patients who completed 8 or more visits in their first 3 months) in wk \
 		104, thus after any experiments have altered the behavior of the system.
 	|
 
 Sankey One and Dones=
-	IF THEN ELSE(Time=FINAL TIME, Starting Rate*MAX(MIN((1-"%Visit1<3mo and More"-"% Go on to 2-7 in <3mo"\
-		),1),0),:NA:)
-	~	pt/Week
+	IF THEN ELSE(Time=FINAL TIME, Starting Rate*MAX(MIN((1-"Actual Starters Who Return Later %"\
+		-"Actual Starters Who Initiate %"),1),0),:NA:)
+	~	pts/wk
 	~	For the Sankey - reporting out the inflow of "One-n-Dones" (i.e, patient \
-		starts who only complete one visit ever) in Week 104, thus after any \
+		starts who only complete one visit ever) in wk 104, thus after any \
 		experiments have altered the behavior of the system. The percent of \
 		"One-n-Dones" is constrained between 0 and 100%, even if user input \
 		accidentally creates a negative %).
 	|
 
-"From1-PL3mo Median Time in Upper Q"=
-	"From1-PL3mo Median Time in Upper Q Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Starters Median Time in Upper Q=
+	From Starters Median Time in Upper Q Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the upper quartile of engagement durations of patients who \
 		(after completing only 1 visit in their first 3 months) complete more \
 		visits in the subsequent months, potentially modified by the user.
@@ -906,34 +906,34 @@ Octane Ratio=
 	~	:SUPPLEMENTARY 
 	|
 
-Starting 1 who can start 2=
+Starting Rate who can Initiate=
 	Starting Psychotherapy who can start 2
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients starting their 1st visit, for patients where there is \
 		capacity for them to start a second visit.
 	|
 
-Ending 1 who go on=
+Ending who can Initiate=
 	"<3mo Visit 1 who can start 2"/Median Time in Visit 1
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients ending their first visit in psychotherapy, if there is \
 		capacity for them to continue care.
 	|
 
-"From2-7-PL3mo Median Time in Upper Q"=
-	"From2-7-PL3mo Median Time in Upper Q Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Initiators Median Time in Upper Q=
+	From Initiators Median Time in Upper Q Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the upper quartile of engagement durations of patients who \
 		(after completing 2-7 visits in their first 3 months) complete more visits \
 		in the subsequent months, potentially modified by the user.
 	|
 
-"%Visit8PL-n-Done"=
+"Actual Completers Who Graduate %"=
 	MAX(MIN(
 	
-	IF THEN ELSE("User-defined %Visit8PL-n-Done"<0,"%Visit8PL-n-Done Data",
-	IF THEN ELSE(Time<Experiment Week, "%Visit8PL-n-Done Data","User-defined %Visit8PL-n-Done"\
+	IF THEN ELSE("User-defined Completers who Graduate %"<0,"Completers Who Graduate %",
+	IF THEN ELSE(Time<Experiment wk, "Completers Who Graduate %","User-defined Completers who Graduate %"\
 		))
 	
 	,1),0)
@@ -941,36 +941,36 @@ Ending 1 who go on=
 	~	Constrained to be between 0 and 100%.
 	|
 
-"From1-PL3mo Median Time in Lower Q"=
-	"From1-PL3mo Median Time in Lower Q Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Starters Median Time in Lower Q=
+	From Starters Median Time in Lower Q Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the lower quartile of engagement durations of patients who \
 		(after completing only 1 visit in their first 3 months) complete more \
 		visits in the subsequent months, potentially modified by the user.
 	|
 
-Percieved New Pt Appt Supply who can start 2=
+Percieved New pts appt Supply who can start 2=
 	SMOOTH(Supply Available for New Pts who can start 2nd visit,Time to Percieve Supply for New Pts\
 		)
-	~	appt/Week
-	~	Schedulers' perception of the appointment supply available for new \
+	~	appt/wk
+	~	Schedulers' perceptsion of the appointment supply available for new \
 		patients, based on the capacity for them to continue care.
 	|
 
-"From1-PL3mo Median Time in Mid Qs"=
-	"From1-PL3mo MedianTime in Mid Qs Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Starters Median Time in Mid Qs=
+	From Starters MedianTime in Mid Qs Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the inner two quartiles of engagement durations of patients \
 		who (after completing only 1 visit in their first 3 months) complete more \
 		visits in the subsequent months, potentially modified by the user.
 	|
 
-"From2-7-PL3mo Median Time in Mid Qs"=
-	"From2-7-PL3mo Median Time in Mid Qs Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Initiators Median Time in Mid Qs=
+	From Initiators Median Time in Mid Qs Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the inner two quartiles of engagement durations of patients \
 		who (after completing 2-7 visits in their first 3 months) complete more \
 		visits in the subsequent months, potentially modified by the user.
@@ -988,18 +988,19 @@ Percieved New Pt Appt Supply who can start 2=
 	|
 
 Supply Available for New Pts who can start 2nd visit=
-	MAX((Appointment Supply+STEP(Additional Appt Supply for New Patients,Experiment Week\
+	MAX((Appointment Supply+STEP(Additional Appointments Available to New Patients,Experiment wk\
 		)-Appointments Used by Existing Patients),0)
-	~	appt/Week
+	~	appt/wk
 	~	All remaining supply, after all existing patients are seen. It is \
 		prevented from going below zero.
 	|
 
-"%Visit1<3mo and More"=
+"Actual Starters Who Return Later %"=
 	MAX(MIN(
 	
-	IF THEN ELSE("User-defined %Visit1<3mo and More"<0,("%Visit1<3mo and More Data"),
-	IF THEN ELSE(Time<Experiment Week, ("%Visit1<3mo and More Data"),"User-defined %Visit1<3mo and More"\
+	IF THEN ELSE("User-defined Starters Who Return Later %"<0,("Starters Who Return Later %"\
+		),
+	IF THEN ELSE(Time<Experiment wk, ("Starters Who Return Later %"),"User-defined Starters Who Return Later %"\
 		))
 	
 	,1),0)
@@ -1009,10 +1010,10 @@ Supply Available for New Pts who can start 2nd visit=
 		The percent of these "One-n-More Laters" is constrained between 0 and 100%.
 	|
 
-"From2-7-PL3mo Median Time in Lower Q"=
-	"From2-7-PL3mo Median Time in Lower Q Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Initiators Median Time in Lower Q=
+	From Initiators Median Time in Lower Q Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the lower quartile of engagement durations of patients who \
 		(after completing 2-7 visits in their first 3 months) complete more visits \
 		in the subsequent months, potentially modified by the user.
@@ -1020,19 +1021,19 @@ Supply Available for New Pts who can start 2nd visit=
 
 Starting Rate=
 	Starting Psychotherapy
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients starting their 1st visit, regardless of whether or not \
 		there is capacity for them to continue care.
 	|
 
 Starting Psychotherapy who can start 2=
-	Percieved New Pt Appt Supply who can start 2*Pts per Appt*New Patient Scheduling Efficiency
-	~	pt/Week
-	~	The number of patients who start Psychotherapy each week, if there is \
+	Percieved New pts appt Supply who can start 2*Pts per appt*New Patient Scheduling Efficiency
+	~	pts/wk
+	~	The number of patients who start Psychotherapy each wk, if there is \
 		capacity for them to continue care......The number of patients who start \
-		Psychotherapy each week, based on the actual appointment supply available \
-		to new patients (including any user adjustments to both "Appointment \
-		Supply" and "Additional Supply for New Patients).
+		Psychotherapy each wk, based on the actual appointment supply available to \
+		new patients (including any user adjustments to both "Appointment Supply" \
+		and "Additional Supply for New Patients).
 	|
 
 "Octane Ratio - Completers"=
@@ -1046,11 +1047,11 @@ Starting Psychotherapy who can start 2=
 	~	:SUPPLEMENTARY 
 	|
 
-"%Visit2-7-n-More<3mo"=
+"Actual Initiators Who Complete %"=
 	MAX(MIN(
 	
-	IF THEN ELSE("User-defined %2-7-n-More<3mo"<0,"%Visit2-7-n-More<3mo Data",
-	IF THEN ELSE(Time<Experiment Week, "%Visit2-7-n-More<3mo Data","User-defined %2-7-n-More<3mo"\
+	IF THEN ELSE("User-defined Initiators Who Complete %"<0,"Initiators Who Complete %",
+	IF THEN ELSE(Time<Experiment wk, "Initiators Who Complete %","User-defined Initiators Who Complete %"\
 		))
 	
 	,1),0)
@@ -1058,62 +1059,63 @@ Starting Psychotherapy who can start 2=
 	~	Constrained to be between 0 and 100%.
 	|
 
-"Percent Change RVI of Patients in Care >3mo"=
+Change in RVI of Patient's Past 3 Months=
 	0
 	~	Dmnl [-0.75,2,0.25]
 	~	Relative change in the median RVI of all patients still in care after \
 		their first 3 months.
 	|
 
-"% Go on to 2-7 in <3mo"=
+"Actual Starters Who Initiate %"=
 	MAX(MIN(
-	IF THEN ELSE("User-defined % Go on to 2-7 in <3mo"<0,"% Go on to 2-7 in <3mo Data",
-	IF THEN ELSE(Time<Experiment Week, "% Go on to 2-7 in <3mo Data","User-defined % Go on to 2-7 in <3mo"\
+	IF THEN ELSE("User-defined Starters Who Initiate %"<0,"Starters Who Initiate %",
+	IF THEN ELSE(Time<Experiment wk, "Starters Who Initiate %","User-defined Starters Who Initiate %"\
 		))
 	,1),0)
 	~	Dmnl
 	~	Constrained to be between 0 and 100%.
 	|
 
-">3mo - Supply Used by FromVisit2-7"=
-	(("From2-7-LowD"*"Frequency >3mo - 2-7Visits-LowD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+Supply Used by Initiators who Return=
+	(("From Initiators-LowD"*"Frequency >3mo - 2-7Visits-LowD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	+
-	("From2-7-MidD"*"Frequency >3mo - 2-7Visits-MidD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+	("From Initiators-MidD"*"Frequency >3mo - 2-7Visits-MidD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	+
-	("From2-7-HighD"*"Frequency >3mo - 2-7Visits-HighD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week)))))
-	~	appt/Week
+	("From Initiators-HighD"*"Frequency >3mo - 2-7Visits-HighD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk)))))
+	~	appt/wk
 	~	For the period after patients' first three months in care, all \
-		appointments used per week by patients' who completed 2-7 visits during \
+		appointments used per wk by patients' who completed 2-7 visits during \
 		their first three months.  By default, this rate is based on appointment \
 		use frequencies estimated from the team's data, but those frequencies can \
 		be adjusted by the user.
 	|
 
-">3mo - Supply Used by FromVisit8PL"=
-	(("From8PL-LowD"*"Frequency >3mo - 8-12Visits-LowD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+Supply Used by Completers who Continue=
+	(("From Completers-LowD"*"Frequency >3mo - 8-12Visits-LowD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	+
-	("From8PL-MidD"*"Frequency >3mo - 8-12Visits-MidD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+	("From Completers-MidD"*"Frequency >3mo - 8-12Visits-MidD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	+
-	("From8PL-HighD"*"Frequency >3mo - 8-12Visits-HighD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week)))))
-	~	appt/Week
+	("From Completers-HighD"*"Frequency >3mo - 8-12Visits-HighD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk)))))
+	~	appt/wk
 	~	For the period after patients' first three months in care, all \
-		appointments used per week by patients' who completed 8 or more visits \
+		appointments used per wk by patients' who completed 8 or more visits \
 		during their first three months.  By default, this rate is based on \
 		appointment use frequencies estimated from the team's data, but those \
 		frequencies can be adjusted by the user.
 	|
 
-"%Visit2-7-n-Done"=
+"Actual Initiators Who Quit Early %"=
 	MAX(MIN(
 	
-	IF THEN ELSE("User-defined %2-7-n-Done"<0,"%Visit2-7-n-Done Data",
-	IF THEN ELSE(Time<Experiment Week, "%Visit2-7-n-Done Data","User-defined %2-7-n-Done"\
+	IF THEN ELSE("User-defined Initiators Who Quit Early %"<0,"Initiators Who Quit Early %"\
+		,
+	IF THEN ELSE(Time<Experiment wk, "Initiators Who Quit Early %","User-defined Initiators Who Quit Early %"\
 		))
 	
 	,1),0)
@@ -1121,23 +1123,24 @@ Starting Psychotherapy who can start 2=
 	~	Constrained to be between 0 and 100%.
 	|
 
-Experiment Week=
+Experiment wk=
 	0
-	~	Week
+	~	wk
 	~	The time when user changes to experiment parameters take effect.
 	|
 
 Appointment Supply=
-	IF THEN ELSE("User-defined Appointment Supply"<0,Baseline Appointment Supply,
+	IF THEN ELSE(User defined Appointment Supply<0,"Appointment Supply (75th percentile)"\
+		,
 	
-	IF THEN ELSE(Time<Experiment Week, Baseline Appointment Supply, "User-defined Appointment Supply"\
+	IF THEN ELSE(Time<Experiment wk, "Appointment Supply (75th percentile)", User defined Appointment Supply\
 		))
-	~	appt/Week
+	~	appt/wk
 	~	Total number of 60 minute Psychotherapy appointments offered by the team \
-		each week.
+		each wk.
 	|
 
-"% of Patients who meet the HS standard who also meet the EBP standard"=
+"Patients with Adequate EBP Templates %"=
 	0.5
 	~	Dmnl [0,1,0.05]
 	~	The percentage of patients who meet the HS standard, who also meet the EBP \
@@ -1146,65 +1149,65 @@ Appointment Supply=
 
 "Bars E9-Final"=
 	SAMPLE IF TRUE(Time=FINAL TIME, Bars E9 , :NA:)
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
-		of "Completor" patients who receive even more visits, at Week 104.
+		of "Completor" patients who receive even more visits, at wk 104.
 	|
 
 "Bars E9-Initial"=
 	SAMPLE IF TRUE(Time=INITIAL TIME, Bars E9 , :NA:)
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
-		of "Completor" patients who receive even more visits, at Week 0.
+		of "Completor" patients who receive even more visits, at wk 0.
 	|
 
 "Bars E6 >3mo-Final"=
 	SAMPLE IF TRUE(Time=FINAL TIME, "Bars E6 >3mo" , :NA:)
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
-		of "Initiator" patients who eventually complete more visits, at Week 104.
+		of "Initiator" patients who eventually complete more visits, at wk 104.
 	|
 
 "Bars E6 >3mo-Initial"=
 	SAMPLE IF TRUE(Time=INITIAL TIME, "Bars E6 >3mo" , :NA:)
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
-		of "Initiator" patients who eventually complete more visits, at Week 0.
+		of "Initiator" patients who eventually complete more visits, at wk 0.
 	|
 
 "Bars E4-Final"=
 	SAMPLE IF TRUE(Time=FINAL TIME, Bars E4, :NA:)
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
-		of "'False' One-and-Done" patients, at Week 104.
+		of "'False' One-and-Done" patients, at wk 104.
 	|
 
 "Bars E4-Initial"=
 	SAMPLE IF TRUE(Time=INITIAL TIME, Bars E4, :NA:)
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
-		of "'False' One-and-Done" patients, at Week 0.
+		of "'False' One-and-Done" patients, at wk 0.
 	|
 
-"From8PL-PL3mo Ending Mid D"=
+From Completers Ending Mid D=
 	MAX(
 	
-	ZIDZ("From8PL-MidD", "From8PL-PL3mo MedianTime in Mid Qs")
+	ZIDZ("From Completers-MidD", From Completers MedianTime in Mid Qs)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of two quarters of patients who (after completing 8 or \
 		more visits in their first 3 months) complete more visits in the \
 		subsequent months, based on the number of patient in treatment and the \
@@ -1212,13 +1215,13 @@ Appointment Supply=
 		going below zero.
 	|
 
-"From1-+PLmo Ending Low D"=
+From Starters Ending Low D=
 	MAX(
 	
-	ZIDZ("From1-LowD", "From1-PL3mo Median Time in Lower Q")
+	ZIDZ("From Starters-LowD", From Starters Median Time in Lower Q)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of one quarter of patients who (after completing only 1 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1226,13 +1229,13 @@ Appointment Supply=
 		below zero.
 	|
 
-"From1-+PLmo Ending Mid D"=
+From Starters Ending Mid D=
 	MAX(
 	
-	ZIDZ("From1-MidD", "From1-PL3mo Median Time in Mid Qs")
+	ZIDZ("From Starters-MidD", From Starters Median Time in Mid Qs)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of two quarters of patients who (after completing only 1 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1241,8 +1244,8 @@ Appointment Supply=
 	|
 
 Bars E8=
-	"Frequency <3mo - 8-12 Visits"*Median Time in Visit 8PL
-	~	appt/pt
+	"Frequency <3mo - 8-12 Visits"*Completers Duration
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment during their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1251,15 +1254,15 @@ Bars E8=
 	|
 
 Bars E9=
-	("PL3mo % starting LowD"*"From8PL-PL3mo Median Time in Lower Q"*"Frequency >3mo - 8-12Visits-LowD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
+	("Starting LowD %"*From Completers Median Time in Lower Q*"Frequency >3mo - 8-12Visits-LowD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
 	+
-	("PL3mo % starting MidD"*"From8PL-PL3mo MedianTime in Mid Qs"*"Frequency >3mo - 8-12Visits-MidD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
+	("Starting MidD %"*From Completers MedianTime in Mid Qs*"Frequency >3mo - 8-12Visits-MidD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
 	+
-	("PL3mo % starting HighD"*"From8PL-PL3mo Median Time in Upper Q"*"Frequency >3mo - 8-12Visits-HighD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
-	~	appt/pt
+	("Starting HighD %"*From Completers Median Time in Upper Q*"Frequency >3mo - 8-12Visits-HighD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1267,25 +1270,25 @@ Bars E9=
 		"Completer" patients who receive even more visits).
 	|
 
-"From2-7-PL3mo Median Time in Lower Q Data"=
+From Initiators Median Time in Lower Q Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C27')
-	~	Week
+	~	wk
 	~	The median of the lower quartile of engagement durations of patients who \
 		(after completing 2-7 visits in their first 3 months) complete more visits \
 		in the subsequent months.
 	|
 
-"From2-7-PL3mo Median Time in Mid Qs Data"=
+From Initiators Median Time in Mid Qs Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C28')
-	~	Week
+	~	wk
 	~	The median of the inner two quartiles of engagement durations of patients \
 		who (after completing 2-7 visits in their first 3 months) complete more \
 		visits in the subsequent months.
 	|
 
-"From2-7-PL3mo Median Time in Upper Q Data"=
+From Initiators Median Time in Upper Q Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C29')
-	~	Week
+	~	wk
 	~	The median of the upper quartile of engagement durations of patients who \
 		(after completing 2-7 visits in their first 3 months) complete more visits \
 		in the subsequent months.
@@ -1293,7 +1296,7 @@ Bars E9=
 
 Bars E3=
 	Median Time in Visit 1*"Frequency <3mo - 1Visit"
-	~	appt/pt
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment during their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1303,15 +1306,15 @@ Bars E3=
 	|
 
 Bars E4=
-	("PL3mo % starting LowD"*"From1-PL3mo Median Time in Lower Q"*"Frequency >3mo - 1Visit-LowD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
+	("Starting LowD %"*From Starters Median Time in Lower Q*"Frequency >3mo - 1Visit-LowD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
 	+
-	("PL3mo % starting MidD"*"From1-PL3mo Median Time in Mid Qs"*"Frequency >3mo - 1Visit-MidD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
+	("Starting MidD %"*From Starters Median Time in Mid Qs*"Frequency >3mo - 1Visit-MidD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
 	+
-	("PL3mo % starting HighD"*"From1-PL3mo Median Time in Upper Q"*"Frequency >3mo - 1Visit-HighD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
-	~	appt/pt
+	("Starting HighD %"*From Starters Median Time in Upper Q*"Frequency >3mo - 1Visit-HighD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1320,8 +1323,8 @@ Bars E4=
 	|
 
 Bars E5=
-	"Frequency <3mo - 2-7Visits-n-done"*"Median Time in Visit 2-7-n-Done"
-	~	appt/pt
+	"Frequency <3mo - 2-7Visits-n-done"*Initiators Who Quit Early Duration
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment during their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1331,8 +1334,8 @@ Bars E5=
 	|
 
 Bars E6=
-	"Frequency <3mo - 2-7Visits-n-More>3mo"*"Median Time in Visit 2-7-n-More>3mo"
-	~	appt/pt
+	"Frequency <3mo - 2-7Visits-n-More>3mo"*Initiators Who Return Duration
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment during their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1342,50 +1345,50 @@ Bars E6=
 	|
 
 "Bars E6 >3mo"=
-	("PL3mo % starting LowD"*"From2-7-PL3mo Median Time in Lower Q"*"Frequency >3mo - 2-7Visits-LowD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
+	("Starting LowD %"*From Initiators Median Time in Lower Q*"Frequency >3mo - 2-7Visits-LowD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
 	+
-	("PL3mo % starting MidD"*"From2-7-PL3mo Median Time in Mid Qs"*"Frequency >3mo - 2-7Visits-MidD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
+	("Starting MidD %"*From Initiators Median Time in Mid Qs*"Frequency >3mo - 2-7Visits-MidD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
 	+
-	("PL3mo % starting HighD"*"From2-7-PL3mo Median Time in Upper Q"*"Frequency >3mo - 2-7Visits-HighD"\
-		*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo",Experiment Week))))
-	~	appt/pt
+	("Starting HighD %"*From Initiators Median Time in Upper Q*"Frequency >3mo - 2-7Visits-HighD"\
+		*(1/(1+STEP(Change in RVI of Patient's Past 3 Months,Experiment wk))))
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment after their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
 		of "Initiator" patients who eventually complete more visits.
 	|
 
-"<3mo - Supply Used by Visit 2-7"=
-	(("<3mo Visit 2-7 -n-done"*"Frequency <3mo - 2-7Visits-n-done")+
-	("<3mo Visit 2-7-n-More<3mo"*"Frequency <3mo - 2-7Visits-n-More<3mo")+
-	("<3mo Visit 2-7-n-More>3mo"*"Frequency <3mo - 2-7Visits-n-More>3mo"))
-	~	appt/Week
-	~	All appointments used per week by patients' second through seventh visits \
+Supply Used by Initiators=
+	((Initiators who will Quit*"Frequency <3mo - 2-7Visits-n-done")+
+	(Initiators who will Continue*"Frequency <3mo - 2-7Visits-n-More<3mo")+
+	(Initiators who will Return*"Frequency <3mo - 2-7Visits-n-More>3mo"))
+	~	appt/wk
+	~	All appointments used per wk by patients' second through seventh visits \
 		during their first three months engaged in care.
 	|
 
-"<3mo - Supply Used by Visit 8PL"=
+Supply Used by Completers=
 	(Patients in Over 7 Visits*"Frequency <3mo - 8-12 Visits")
-	~	appt/Week
-	~	All appointments used per week by patients' eighth and over visits during \
+	~	appt/wk
+	~	All appointments used per wk by patients' eighth and over visits during \
 		their first three months engaged in care.
 	|
 
-"<3mo - Supply Used by Visit1"=
+Supply Used by New Patients=
 	(Patients in First Visit*"Frequency <3mo - 1Visit")
-	~	appt/Week
-	~	All appointments used per week by patients' first visits.
+	~	appt/wk
+	~	All appointments used per wk by patients' first visits.
 	|
 
-"From1-PL3mo Ending High D"=
+From Starters Ending High D=
 	MAX(
 	
-	ZIDZ("From1-HighD", "From1-PL3mo Median Time in Upper Q")
+	ZIDZ("From Starters-HighD", From Starters Median Time in Upper Q)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of one quarter of patients who (after completing only 1 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1393,37 +1396,37 @@ Bars E6=
 		below zero.
 	|
 
-"From1-PL3mo Median Time in Lower Q Data"=
+From Starters Median Time in Lower Q Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C24')
-	~	Week
+	~	wk
 	~	The median of the lower quartile of engagement durations of patients who \
 		(after completing only 1 visit in their first 3 months) complete more \
 		visits in the subsequent months.
 	|
 
-"From1-PL3mo MedianTime in Mid Qs Data"=
+From Starters MedianTime in Mid Qs Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C25')
-	~	Week
+	~	wk
 	~	The median of the inner two quartiles of engagement durations of patients \
 		who (after completing only 1 visit in their first 3 months) complete more \
 		visits in the subsequent months.
 	|
 
-"From1-PL3mo Median Time in Upper Q Data"=
+From Starters Median Time in Upper Q Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C26')
-	~	Week
+	~	wk
 	~	The median of the upper quartile of engagement durations of patients who \
 		(after completing only 1 visit in their first 3 months) complete more \
 		visits in the subsequent months.
 	|
 
-"From2-7-PL3mo Ending Low D"=
+From Initiators Ending Low D=
 	MAX(
 	
-	ZIDZ("From2-7-LowD", "From2-7-PL3mo Median Time in Lower Q")
+	ZIDZ("From Initiators-LowD", From Initiators Median Time in Lower Q)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of one quarter of patients who (after completing 2-7 \
 		visits in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1431,13 +1434,13 @@ Bars E6=
 		below zero.
 	|
 
-"From8PL-PL3mo Ending Low D"=
+From Completers Ending Low D=
 	MAX(
 	
-	ZIDZ("From8PL-LowD", "From8PL-PL3mo Median Time in Lower Q")
+	ZIDZ("From Completers-LowD", From Completers Median Time in Lower Q)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of one quarter of patients who (after completing 8 or more \
 		visits in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1445,26 +1448,26 @@ Bars E6=
 		below zero.
 	|
 
-"From8PL-PL3mo Median Time in Lower Q"=
-	"From8PL-PL3mo Median Time in Lower Q Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Completers Median Time in Lower Q=
+	From Completers Median Time in Lower Q Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the lower quartile of engagement durations of patients who \
 		(after completing 8 or more visits in their first 3 months) complete more \
 		visits in the subsequent months, potentially modified by the user.
 	|
 
-"From8PL-PL3mo Median Time in Mid Qs Data"=
+From Completers Median Time in Mid Qs Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C31')
-	~	Week
+	~	wk
 	~	The median of the inner two quartiles of engagement durations of patients \
 		who (after completing 8 or more visits in their first 3 months) complete \
 		more visits in the subsequent months.
 	|
 
 Bars E7=
-	"Frequency <3mo - 2-7Visits-n-More<3mo"*"Median Time in Visit 2-7-More<3mo"
-	~	appt/pt
+	"Frequency <3mo - 2-7Visits-n-More<3mo"*Initiators Who Graduate Duration
+	~	appt/pts
 	~	For calculating "Sankey bar heights" - The total number of visits for the \
 		average time in treatment during their first three months in care (i.e., \
 		the product of the frequency of visits and their total time in treatment) \
@@ -1472,32 +1475,32 @@ Bars E7=
 		"Completers").
 	|
 
-">3mo - Supply Used by FromVisit1"=
+Supply Used by New Patients who Return=
 	(
-	("From1-LowD"*"Frequency >3mo - 1Visit-LowD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+	("From Starters-LowD"*"Frequency >3mo - 1Visit-LowD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	+
-	("From1-MidD"*"Frequency >3mo - 1Visit-MidD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+	("From Starters-MidD"*"Frequency >3mo - 1Visit-MidD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	+
-	("From1-HighD"*"Frequency >3mo - 1Visit-HighD"*(1/(1+STEP("Percent Change RVI of Patients in Care >3mo"\
-		,Experiment Week))))
+	("From Starters-HighD"*"Frequency >3mo - 1Visit-HighD"*(1/(1+STEP(Change in RVI of Patient's Past 3 Months\
+		,Experiment wk))))
 	)
-	~	appt/Week
+	~	appt/wk
 	~	For the period after patients' first three months in care, all \
-		appointments used per week by patients' who completed only one visit \
-		during their first three months.  By default, this rate is based on \
-		appointment use frequencies estimated from the team's data, but those \
-		frequencies can be adjusted by the user.
+		appointments used per wk by patients' who completed only one visit during \
+		their first three months.  By default, this rate is based on appointment \
+		use frequencies estimated from the team's data, but those frequencies can \
+		be adjusted by the user.
 	|
 
-"From2-7-PL3mo Ending High D"=
+From Initiators Ending High D=
 	MAX(
 	
-	ZIDZ( "From2-7-HighD", "From2-7-PL3mo Median Time in Upper Q")
+	ZIDZ( "From Initiators-HighD", From Initiators Median Time in Upper Q)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of one quarter of patients who (after completing 2-7 \
 		visits in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1505,21 +1508,21 @@ Bars E7=
 		below zero.
 	|
 
-"From8PL-PL3mo Median Time in Lower Q Data"=
+From Completers Median Time in Lower Q Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C30')
-	~	Week
+	~	wk
 	~	The median of the lower quartile of engagement durations of patients who \
 		(after completing 8 or more visits in their first 3 months) complete more \
 		visits in the subsequent months.
 	|
 
-"From2-7-PL3mo Ending Mid D"=
+From Initiators Ending Mid D=
 	MAX(
 	
-	ZIDZ("From2-7-MidD", "From2-7-PL3mo Median Time in Mid Qs")
+	ZIDZ("From Initiators-MidD", From Initiators Median Time in Mid Qs)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of two quarters of patients who (after completing 2-7 \
 		visits in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1527,22 +1530,22 @@ Bars E7=
 		below zero.
 	|
 
-"From8PL-PL3mo MedianTime in Mid Qs"=
-	"From8PL-PL3mo Median Time in Mid Qs Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Completers MedianTime in Mid Qs=
+	From Completers Median Time in Mid Qs Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the inner two quartiles of engagement durations of patients \
 		who (after completing 8 or more visits in their first 3 months) complete \
 		more visits in the subsequent months, potentially modified by the user.
 	|
 
-"From8PL-PL3mo Ending High D"=
+From Completers Ending High D=
 	MAX(
 	
-	ZIDZ("From8PL-HighD", "From8PL-PL3mo Median Time in Upper Q")
+	ZIDZ("From Completers-HighD", From Completers Median Time in Upper Q)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	The ending rate of one quarter of patients who (after completing 8 or more \
 		visits in their first 3 months) complete more visits in the subsequent \
 		months, based on the number of patient in treatment and the median \
@@ -1550,18 +1553,18 @@ Bars E7=
 		below zero.
 	|
 
-"From8PL-PL3mo Median Time in Upper Q"=
-	"From8PL-PL3mo Median Time in Upper Q Data"*(1+STEP("Percent Change Duration of Pts in Care >3mo"\
-		,Experiment Week))
-	~	Week
+From Completers Median Time in Upper Q=
+	From Completers Median Time in Upper Q Data*(1+STEP(Change in Engagement Time of Patients Past 3 Months\
+		,Experiment wk))
+	~	wk
 	~	The median of the upper quartile of engagement durations of patients who \
 		(after completing 2-7 visits in their first 3 months) complete more visits \
 		in the subsequent months, potentially modified by the user.
 	|
 
-"From8PL-PL3mo Median Time in Upper Q Data"=
+From Completers Median Time in Upper Q Data=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C32')
-	~	Week
+	~	wk
 	~	The median of the upper quartile of engagement durations of patients who \
 		(after completing 2-7 visits in their first 3 months) complete more visits \
 		in the subsequent months.
@@ -1569,79 +1572,79 @@ Bars E7=
 
 "HS Bronze Standard - All"=
 	"Total Pts <3months"
-	~	pt
+	~	pts
 	~	Number of patients who started psychotherapy in the past three months.
 	|
 
 HS Bronze Standard for AUD=
 	"# Pts <3mo in Team w/AUD"
-	~	pt
+	~	pts
 	~	"Health Services definition"-based lowest quality standard - the number of \
 		patients with AUD who started psychotherapy in the past 3 months.
 	|
 
 HS Bronze Standard for Depression=
 	"# Pts <3mo in Team with Depression"
-	~	pt
+	~	pts
 	~	"Health Services definition"-based lowest quality standard - the number of \
 		patients with depression who started psychotherapy in the past 3 months.
 	|
 
 HS Bronze Standard for OUD=
 	"# Pts <3mo in Team w/OUD"
-	~	pt
+	~	pts
 	~	"Health Services definition"-based lowest quality standard - the number of \
 		patients with OUD who started psychotherapy in the past 3 months.
 	|
 
 HS Bronze Standard for PTSD=
 	"# Pts <3mo in Team w/PTSD"
-	~	pt
+	~	pts
 	~	"Health Services definition"-based lowest quality standard - the number of \
 		patients with PTSD who started psychotherapy in the past 3 months.
 	|
 
 "HS Gold Standard - All"=
 	Patients in Over 7 Visits
-	~	pt
+	~	pts
 	~	Number of patients who are receiving a full, timely dose in their first 3 \
 		months (i.e., completed 8+ visits within 3 months).  These are the \
 		"Completers" (but they may or may not be "Graduators").
 	|
 
 HS Gold Standard for PTSD=
-	(Patients in Over 7 Visits*"% of Total Pts <3mo w/PTSD")
-	~	pt
+	(Patients in Over 7 Visits*"PTSD within 3 months %")
+	~	pts
 	~	"Health Services definition"-based highest quality standard - the number \
 		of patients with PTSD who completed psychotherapy in the past 3 months.
 	~	:SUPPLEMENTARY 
 	|
 
 "HS Silver Standard - All"=
-	"# Total Pts <3mo w/2-7 Visits"
-	~	pt
+	Total Initiators
+	~	pts
 	~	Number of patients who are completing 2-7 visits in their first 3 months.  \
 		These are the "Initiators" (but they may or may not become "Completers").
 	|
 
 HS Gold Standard for OUD=
-	(Patients in Over 7 Visits*"% of Total Pts <3mo w/OUD")
-	~	pt
+	(Patients in Over 7 Visits*"OUD within 3 months %")
+	~	pts
 	~	"Health Services definition"-based highest quality standard - the number \
 		of patients with OUD who completed psychotherapy in the past 3 months.
 	~	:SUPPLEMENTARY 
 	|
 
 HS Gold Standard for Depression=
-	(Patients in Over 7 Visits*"% of Total Pts <3mo w/Depression")
-	~	pt
+	(Patients in Over 7 Visits*"DEP within 3 months %")
+	~	pts
 	~	"Health Services definition"-based highest quality standard - the number \
 		of patients with depression who completed psychotherapy in the past 3 \
 		months.
 	~	:SUPPLEMENTARY 
 	|
 
-"Percent Change Duration of Pts in Care >3mo"=
+Change in Engagement Time of Patients Past 3 Months=
 	0
 	~	Dmnl [-0.75,2,0.25]
 	~	Relative change in the median engagement duration for all patients still \
@@ -1649,8 +1652,8 @@ HS Gold Standard for Depression=
 	|
 
 HS Gold Standard for AUD=
-	(Patients in Over 7 Visits*"% of Total Pts <3mo w/AUD")
-	~	pt
+	(Patients in Over 7 Visits*"AUD within 3 months %")
+	~	pts
 	~	"Health Services definition"-based highest quality standard - the number \
 		of patients with AUD who completed psychotherapy in the past 3 months.
 	~	:SUPPLEMENTARY 
@@ -1659,32 +1662,32 @@ HS Gold Standard for AUD=
 Appointments Used by Existing Patients=
 	"Supply Used by Pts <3mo"+
 	"Supply Used by Pts >3mo"
-	~	appt/Week
-	~	Sum of all appointment used per week by all possible patient service use \
+	~	appt/wk
+	~	Sum of all appointment used per wk by all possible patient service use \
 		pathways.
 	|
 
 Graduation Rate=
-	Ending First 3months of Psychotherapy*"%Visit8PL-n-Done"
-	~	pt/Week
+	Ending After 8 or More Visits Rate*"Actual Completers Who Graduate %"
+	~	pts/wk
 	~	The rate at which patients end their engagement with psychotherapy after \
 		receiving a timely, full dose, i.e., the desired pattern of engagement.
 	~	:SUPPLEMENTARY 
 	|
 
 "Supply Used by Pts <3mo"=
-	"<3mo - Supply Used by Visit1"
-	+"<3mo - Supply Used by Visit 2-7"
-	+"<3mo - Supply Used by Visit 8PL"
-	~	appt/Week
-	~	Sum of all appointments used per week by patients in first 3 months of \
+	Supply Used by New Patients
+	+Supply Used by Initiators
+	+Supply Used by Completers
+	~	appt/wk
+	~	Sum of all appointments used per wk by patients in first 3 months of \
 		engagement.
 	|
 
 Appointments Available for New Patients=
-	MAX((Appointment Supply-Appointments Used by Existing Patients),0)+STEP(Additional Appt Supply for New Patients\
-		,Experiment Week)
-	~	appt/Week
+	MAX((Appointment Supply-Appointments Used by Existing Patients),0)+STEP(Additional Appointments Available to New Patients\
+		,Experiment wk)
+	~	appt/wk
 	~	All remaining supply, after all existing patients are seen. Users can also \
 		set aside additional appointments specifically for new patients, which \
 		allows the team to start more patients (i.e., they receive a first visit) \
@@ -1693,26 +1696,26 @@ Appointments Available for New Patients=
 	|
 
 Starting Psychotherapy=
-	Percieved New Pt Appt Supply*Pts per Appt*New Patient Scheduling Efficiency
-	~	pt/Week
-	~	The number of patients who start Psychotherapy each week, based on the \
+	Percieved New pts appt Supply*Pts per appt*New Patient Scheduling Efficiency
+	~	pts/wk
+	~	The number of patients who start Psychotherapy each wk, based on the \
 		actual appointment supply available to new patients (including any user \
 		adjustments to both "Appointment Supply" and "Additional Supply for New \
 		Patients).
 	|
 
-Percieved New Pt Appt Supply=
+Percieved New pts appt Supply=
 	SMOOTH(Appointments Available for New Patients,Time to Percieve Supply for New Pts)
-	~	appt/Week
-	~	Schedulers' perception of the appointment supply available for new \
+	~	appt/wk
+	~	Schedulers' perceptsion of the appointment supply available for new \
 		patients, regardless of the capacity for them to continue care.
 	|
 
 Time to Percieve Supply for New Pts=
 	4
-	~	Week
+	~	wk
 	~	Time for schedulers to percieve and act upon changes in new patient \
-		appointment supply.  Set to 4 weeks, to reflect information and process \
+		appointment supply.  Set to 4 wks, to reflect information and process \
 		delays.
 	|
 
@@ -1725,45 +1728,44 @@ Start Rate Relative to Data=
 
 Team Data on New Patients Starts=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C33')
-	~	pt/Week
-	~	From the team's data: psycho60 visits/appts for new patients per week.
+	~	pts/wk
+	~	From the team's data: psycho60 visits/appts for new patients per wk.
 	|
 
-Baseline Appointment Supply=
+"Appointment Supply (75th percentile)"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C35')
-	~	appt/Week
-	~	The baseline number of the appointments offered each week, taken from the \
+	~	appt/wk
+	~	The baseline number of the appointments offered each wk, taken from the \
 		team's data. However, the number of appointments offered specifically for \
 		this service is currently unmeasurable.  We estimate the available supply \
-		from the upper quartile of appointments completed each week for this \
-		service.
+		from the upper quartile of appointments completed each wk for this service.
 	|
 
-"User-defined Appointment Supply"=
+User defined Appointment Supply=
 	-1
-	~	appt/Week [-1,200,1]
+	~	appt/wk [-1,200,1]
 	~	Manually adjust the number of official appointments offered, with the \
-		assumption that these appoints come at the expense of appointments offered \
-		for other services.
+		assumptsion that these appoints come at the expense of appointments \
+		offered for other services.
 	|
 
-Additional Appt Supply for New Patients=
+Additional Appointments Available to New Patients=
 	0
-	~	appt/Week [0,30,0.5]
+	~	appt/wk [0,30,0.5]
 	~	Manually adjust the number of additional appointments allocated \
-		specifically to new patients each week, with the assumption that these \
+		specifically to new patients each wk, with the assumptsion that these \
 		appointments come from reducing appointments in other services.
 	|
 
-"Starting Psychotherapy 2-7-n-Done"=
-	Ending 1 who go on*"% Go on to 2-7 in <3mo"*"%Visit2-7-n-Done"
-	~	pt/Week
+Initiation Rate who will Quit=
+	Ending who can Initiate*"Actual Starters Who Initiate %"*"Actual Initiators Who Quit Early %"
+	~	pts/wk
 	~	Rate of patients starting their 2nd visit, who will complete 2-7 visits in \
 		their first three months in care, but not continue engagement to receive \
 		full dose.
 	|
 
-"User-defined %2-7-n-More<3mo"=
+"User-defined Initiators Who Complete %"=
 	-0.05
 	~	Dmnl [-0.05,1,0.05]
 	~	This value replaces the estimate from the team's data (the value of -0.05 \
@@ -1772,7 +1774,7 @@ Additional Appt Supply for New Patients=
 		multiple engagement pathways simultaneously.
 	|
 
-"% Go on to 2-7 in <3mo Data"=
+"Starters Who Initiate %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C6')
 	~	Dmnl
 	~	The percent of patients (having completed their first appointment) who \
@@ -1780,7 +1782,7 @@ Additional Appt Supply for New Patients=
 		their first 3 months.
 	|
 
-"%Visit8PL-n-Done Data"=
+"Completers Who Graduate %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C5')
 	~	Dmnl
 	~	The percent of patients who (after completing 8+ visits in first 3 months) \
@@ -1788,14 +1790,14 @@ Additional Appt Supply for New Patients=
 		i.e., "Completers who Graduate."
 	|
 
-"%Visit1<3mo and More Data"=
+"Starters Who Return Later %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C3')
 	~	Dmnl
 	~	The percent of patients who complete only 1 visit in their first 3 months \
 		and then completed more visits afterward.
 	|
 
-"User-defined %Visit1<3mo and More"=
+"User-defined Starters Who Return Later %"=
 	-0.05
 	~	Dmnl [-0.05,1,0.05]
 	~	This value replaces the estimate from the team's data (the value of -0.05 \
@@ -1804,14 +1806,14 @@ Additional Appt Supply for New Patients=
 		pursuing multiple engagement pathways simultaneously.
 	|
 
-"User-defined %Visit8PL-n-Done"=
+"User-defined Completers who Graduate %"=
 	-0.05
 	~	Dmnl [-0.05,1,0.05]
 	~	This value replaces the estimate from the team's data (the value of -0.05 \
 		uses the team's data).
 	|
 
-"%Visit2-7-n-Done Data"=
+"Initiators Who Quit Early %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C4')
 	~	Dmnl
 	~	The percent of patients who (after completing 2-7 visits in their first 3 \
@@ -1819,7 +1821,7 @@ Additional Appt Supply for New Patients=
 		visits in their first 3 months) nor return for more visits after 3 months.
 	|
 
-"%Visit2-7-n-More<3mo Data"=
+"Initiators Who Complete %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C7')
 	~	Dmnl
 	~	The percent of patients who (after completing 2-7 visits in their first 3 \
@@ -1828,7 +1830,7 @@ Additional Appt Supply for New Patients=
 		become "Completers."
 	|
 
-"User-defined % Go on to 2-7 in <3mo"=
+"User-defined Starters Who Initiate %"=
 	-0.05
 	~	Dmnl [-0.05,1,0.05]
 	~	This value replaces the estimate from the team's data (the value of -0.05 \
@@ -1837,7 +1839,7 @@ Additional Appt Supply for New Patients=
 		pursuing multiple engagement pathways simultaneously.
 	|
 
-"User-defined %2-7-n-Done"=
+"User-defined Initiators Who Quit Early %"=
 	-0.05
 	~	Dmnl [-0.05,1,0.05]
 	~	This value replaces the estimate from the team's data (the value of -0.05 \
@@ -1847,23 +1849,23 @@ Additional Appt Supply for New Patients=
 	|
 
 "Supply Used by Pts >3mo"=
-	">3mo - Supply Used by FromVisit1"+">3mo - Supply Used by FromVisit2-7"+">3mo - Supply Used by FromVisit8PL"
-	~	appt/Week
-	~	Sum of all appointment used per week by patients who continue after first \
-		3 months of engagement.
+	Supply Used by New Patients who Return+Supply Used by Initiators who Return+Supply Used by Completers who Continue
+	~	appt/wk
+	~	Sum of all appointment used per wk by patients who continue after first 3 \
+		months of engagement.
 	|
 
 Patients in Visits 2 to 7=
-	"<3mo Visit 2-7 -n-done"+"<3mo Visit 2-7-n-More>3mo"+"<3mo Visit 2-7-n-More<3mo"
-	~	pt
+	Initiators who will Quit+Initiators who will Return+Initiators who will Continue
+	~	pts
 	~		~	:SUPPLEMENTARY 
 	|
 
 "Frequency <3mo - 2-7Visits-n-done"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C9')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -1871,9 +1873,9 @@ Patients in Visits 2 to 7=
 
 "Frequency <3mo - 2-7Visits-n-More<3mo"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C11')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -1881,190 +1883,190 @@ Patients in Visits 2 to 7=
 
 "Frequency <3mo - 8-12 Visits"=
 	"Frequency <3mo - 2-7Visits-n-More<3mo"
-	~	appt/(Week*pt) [?,?,0.2]
-	~	The average number of appointments per patient per week, which is nearly \
+	~	appt/(wk*pts) [?,?,0.2]
+	~	The average number of appointments per patient per wk, which is nearly \
 		identical to the frequency of patients who complete 2-7 visits and then go \
 		on to more visits in their first three months engaged in care.
 	|
 
 "# Pts <3mo in Team w/AUD"=
-	"% of Total Pts <3mo w/AUD"*"Total Pts <3months"
-	~	pt
+	"AUD within 3 months %"*"Total Pts <3months"
+	~	pts
 	~		|
 
 "# Pts <3mo in Team w/OUD"=
-	"% of Total Pts <3mo w/OUD"*"Total Pts <3months"
-	~	pt
+	"OUD within 3 months %"*"Total Pts <3months"
+	~	pts
 	~		|
 
 "# Pts <3mo in Team w/PTSD"=
-	"% of Total Pts <3mo w/PTSD"*"Total Pts <3months"
-	~	pt
+	"PTSD within 3 months %"*"Total Pts <3months"
+	~	pts
 	~		|
 
 "# Pts <3mo in Team with Depression"=
-	"% of Total Pts <3mo w/Depression"*"Total Pts <3months"
-	~	pt
+	"DEP within 3 months %"*"Total Pts <3months"
+	~	pts
 	~		|
 
-"# Total Pts <3mo w/2-7 Visits"=
-	"<3mo Visit 2-7 -n-done"+"<3mo Visit 2-7-n-More>3mo"+"<3mo Visit 2-7-n-More<3mo"
-	~	pt
+Total Initiators=
+	Initiators who will Quit+Initiators who will Return+Initiators who will Continue
+	~	pts
 	~	Number of patients who are completing 2-7 visits in their first 3 months.  \
 		These are the "Initiators" (but they may or may not become "Completers").
 	|
 
-Median Time in Visit 8PL=
-	MAX(12-Median Time in Visit 1-"Median Time in Visit 2-7-More<3mo",1)
-	~	Week [?,?,1]
+Completers Duration=
+	MAX(12-Median Time in Visit 1-Initiators Who Graduate Duration,1)
+	~	wk [?,?,1]
 	~	Engagement time for patients who complete 8 or more visits in their first \
 		three months, based on the median time it takes these patients to complete \
-		their first 7 visits. Constrained from going below 1 week.
+		their first 7 visits. Constrained from going below 1 wk.
 	|
 
-"% of Total Pts <3mo w/AUD"=
+"AUD within 3 months %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C46')
 	~	Dmnl
 	~		|
 
-"% of Total Pts <3mo w/OUD"=
+"OUD within 3 months %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C47')
 	~	Dmnl
 	~		|
 
-"% of Total Pts <3mo w/PTSD"=
+"PTSD within 3 months %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C44')
 	~	Dmnl
 	~		|
 
 Patients in Care More Than 3 Months=
 	OneAfter+TwoSevenAfter+EightPlusAfter
-	~	pt
+	~	pts
 	~	Sum of all patients in their subsequent months in care.
 	|
 
-"% of Total Pts <3mo w/Depression"=
+"DEP within 3 months %"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C45')
 	~	Dmnl
 	~	using patients that started within the last three months in the data
 	|
 
 "Total Pts <3months"=
-	Patients in First Visit+"<3mo Visit 2-7-n-More>3mo"+Patients in Over 7 Visits+"<3mo Visit 2-7 -n-done"\
-		+"<3mo Visit 2-7-n-More<3mo"
-	~	pt
+	Patients in First Visit+Initiators who will Return+Patients in Over 7 Visits+Initiators who will Quit\
+		+Initiators who will Continue
+	~	pts
 	~	Number of patients who started psychotherapy in the past three months.
 	|
 
 Total Pts in Psych=
 	Patients in Care More Than 3 Months+"Total Pts <3months"
-	~	pt
+	~	pts
 	~	The total number of patients in psychotherapy.
 	|
 
 Ending During Visit 2 to 7 Rate=
 	MAX(
 	
-	ZIDZ("<3mo Visit 2-7 -n-done", "Median Time in Visit 2-7-n-Done")
+	ZIDZ(Initiators who will Quit, Initiators Who Quit Early Duration)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients completing their 2-7th visit, but who will not continue \
 		engagement to receive a full dose. It is constrained from going below zero.
 	|
 
-Completion Rate=
+Continuting on to Visit 8 Rate=
 	MAX(
 	
-	ZIDZ("<3mo Visit 2-7-n-More<3mo", "Median Time in Visit 2-7-More<3mo")
+	ZIDZ(Initiators who will Continue, Initiators Who Graduate Duration)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients ending their 2-7th visit, who will complete 2-7 visits in \
 		less than 3 months and go on to complete 8 or more visits in that period.  \
 		This is the desired engagement pattern. It is constrained from going below \
 		zero.
 	|
 
-"From2-7-PL3mo into High D"=
-	"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"*"PL3mo % starting HighD"
-	~	pt/Week
+From Initiators into High D=
+	"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"*"Starting HighD %"
+	~	pts/wk
 	~	The starting rate of one quarter of patients who (after completing 2-7 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months.
 	|
 
-"Median Time in Visit 2-7-More<3mo"=
+Initiators Who Graduate Duration=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C14')
-	~	Week
+	~	wk
 	~	Median engagement time estimated from the team's own data for patients in \
 		their 2-7th visit, who will go on to 8 or more visits in the first three \
 		months.
 	|
 
-"Median Time in Visit 2-7-n-Done"=
+Initiators Who Quit Early Duration=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C13')
-	~	Week
+	~	wk
 	~	Median engagement time estimated from the team's own data for patients in \
 		their 2-7th visit, who will not continue care after the first three months.
 	|
 
 OneAfter=
-	"From1-LowD"+"From1-MidD"+"From1-HighD"
-	~	pt
+	"From Starters-LowD"+"From Starters-MidD"+"From Starters-HighD"
+	~	pts
 	~	Sum of all patients who, after completing only 1 visit in their first 3 \
 		months in care, complete more visits in subsequent months.
 	|
 
-"Starting Psychotherapy 2-7-n-More<3mo"=
-	Ending 1 who go on*"% Go on to 2-7 in <3mo"*"%Visit2-7-n-More<3mo"
-	~	pt/Week
+Initiation Rate who will Complete=
+	Ending who can Initiate*"Actual Starters Who Initiate %"*"Actual Initiators Who Complete %"
+	~	pts/wk
 	~	Rate of patients starting their 2nd visit, who will complete 2-7 visits in \
 		less than 3 months and go on to complete 8 or more visits in that period.  \
 		This is the desired engagement pattern.
 	|
 
-"From2-7-PL3mo into Mid D"=
-	"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"*"PL3mo % starting MidD"
-	~	pt/Week
+From Initiators into Mid D=
+	"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"*"Starting MidD %"
+	~	pts/wk
 	~	The starting rate of two quarters of patients who (after completing 2-7 \
 		visits in their first 3 months) complete more visits in the subsequent \
 		months.
 	|
 
-"From2-7-PL3mo into Low D"=
-	"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"*"PL3mo % starting LowD"
-	~	pt/Week
+From Initiators into Low D=
+	"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"*"Starting LowD %"
+	~	pts/wk
 	~	The starting rate of one quarter of patients who (after completing 2-7 \
 		visit in their first 3 months) complete more visits in the subsequent \
 		months.
 	|
 
 TwoSevenAfter=
-	"From2-7-LowD"+"From2-7-MidD"+"From2-7-HighD"
-	~	pt
+	"From Initiators-LowD"+"From Initiators-MidD"+"From Initiators-HighD"
+	~	pts
 	~	Sum of all patients who, after completing 2-7 visits in their first 3 \
 		months in care, complete more visits in subsequent months.
 	|
 
-"Starting Psychotherapy- 8PL"=
-	Completion Rate
-	~	pt/Week
+Starting Visit 8=
+	Continuting on to Visit 8 Rate
+	~	pts/wk
 	~	Rate of patients starting their 8th visit, who will complete 8 or more \
 		visits in their first 3 months.  This is the desired pattern of engagement.
 	|
 
 EightPlusAfter=
-	"From8PL-LowD"+"From8PL-MidD"+"From8PL-HighD"
-	~	pt
+	"From Completers-LowD"+"From Completers-MidD"+"From Completers-HighD"
+	~	pts
 	~	Sum of all patients who, after completing 8 or more visits in their first \
 		3 months in care, complete more visits in subsequent months.
 	|
 
-"Starting Psychotherapy- 2-7-n->3mo"=
-	Ending 1 who go on*"% Go on to 2-7 in <3mo"*(1-"%Visit2-7-n-More<3mo"-"%Visit2-7-n-Done"\
-		)
-	~	pt/Week
+Initation Rate who will Return=
+	Ending who can Initiate*"Actual Starters Who Initiate %"*(1-"Actual Initiators Who Complete %"\
+		-"Actual Initiators Who Quit Early %")
+	~	pts/wk
 	~	Rate of patients starting their 2nd visit, who will go on to complete less \
 		than 8 visits in their first 3 months.
 	|
@@ -2077,99 +2079,99 @@ New Patient Scheduling Efficiency=
 		patients).
 	|
 
-Pts per Appt=
+Pts per appt=
 	1
-	~	pt/appt
-	~	Always 1 patient per appointment, except for group visits.
+	~	pts/appt
+	~	Always 1 patient per appointment, excepts for group visits.
 	|
 
-"From8PL-HighD"= INTEG (
-	"From8PL-PL3mo into High D"-"From8PL-PL3mo Ending High D",
+"From Completers-HighD"= INTEG (
+	From Completers into High D-From Completers Ending High D,
 		0)
-	~	pt
+	~	pts
 	~	The upper quartile of patients who, after completing 8 or more visits in \
 		their first 3 months in care, complete more visits in subsequent months.
 	|
 
-"From8PL-LowD"= INTEG (
-	"From8PL-PL3mo into Low D"-"From8PL-PL3mo Ending Low D",
+"From Completers-LowD"= INTEG (
+	From Completers into Low D-From Completers Ending Low D,
 		0)
-	~	pt
+	~	pts
 	~	The lower quartile of patients who, after completing 8 or more visits in \
 		their first 3 months in care, complete more visits in subsequent months.
 	|
 
-"From8PL-MidD"= INTEG (
-	"From8PL-PL3mo into Mid D"-"From8PL-PL3mo Ending Mid D",
+"From Completers-MidD"= INTEG (
+	From Completers into Mid D-From Completers Ending Mid D,
 		0)
-	~	pt
+	~	pts
 	~	The inner two quartiles of patients who, after completing 8 or more visits \
 		in their first 3 months in care, complete more visits in subsequent months.
 	|
 
 "Frequency >3mo - 1Visit-MidD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C16')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
 	|
 
-"PL3mo % starting HighD"=
+"Starting HighD %"=
 	0.25
 	~	Dmnl [0,1]
 	~	Used to divide up the starting rate into quartiles.
 	|
 
-"PL3mo % starting LowD"=
+"Starting LowD %"=
 	0.25
 	~	Dmnl
 	~	Used to divide up the starting rate into quartiles.
 	|
 
-"PL3mo % starting MidD"=
+"Starting MidD %"=
 	0.5
 	~	Dmnl
 	~	Used to divide up the starting rate into quartiles.
 	|
 
-"From1-LowD"= INTEG (
-	"From1-PL3mo into Low D"-"From1-+PLmo Ending Low D",
+"From Starters-LowD"= INTEG (
+	From Starters into Low D-From Starters Ending Low D,
 		0)
-	~	pt
+	~	pts
 	~	The lower quartile of patients who, after completing only 1 visit in their \
 		first 3 months in care, complete more visits in subsequent months.
 	|
 
 Median Time in Visit 1=
 	1
-	~	Week
+	~	wk
 	~	Engagement time for patients completing their first visit.
 	|
 
-"From2-7-LowD"= INTEG (
-	"From2-7-PL3mo into Low D"-"From2-7-PL3mo Ending Low D",
+"From Initiators-LowD"= INTEG (
+	From Initiators into Low D-From Initiators Ending Low D,
 		0)
-	~	pt
+	~	pts
 	~	The lower quartile of patients who, after completing 2-7 visits in their \
 		first 3 months in care, complete more visits in subsequent months.
 	|
 
-"From2-7-MidD"= INTEG (
-	"From2-7-PL3mo into Mid D"-"From2-7-PL3mo Ending Mid D",
+"From Initiators-MidD"= INTEG (
+	From Initiators into Mid D-From Initiators Ending Mid D,
 		0)
-	~	pt
+	~	pts
 	~	The inner two quartiles of patients who, after completing 2-7 visits in \
 		their first 3 months in care, complete more visits in subsequent months.
 	|
 
 "Frequency >3mo - 8-12Visits-MidD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C22')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2177,9 +2179,9 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 1Visit-LowD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C15')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2187,9 +2189,9 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 2-7Visits-HighD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C20')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2197,9 +2199,9 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 2-7Visits-LowD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C18')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2207,9 +2209,9 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 1Visit-HighD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C17')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2217,9 +2219,9 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 8-12Visits-HighD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C23')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2227,9 +2229,9 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 8-12Visits-LowD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C21')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2237,67 +2239,67 @@ Median Time in Visit 1=
 
 "Frequency >3mo - 2-7Visits-MidD"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C19')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
 	|
 
-"From2-7-HighD"= INTEG (
-	"From2-7-PL3mo into High D"-"From2-7-PL3mo Ending High D",
+"From Initiators-HighD"= INTEG (
+	From Initiators into High D-From Initiators Ending High D,
 		0)
-	~	pt
+	~	pts
 	~	The upper quartile of patients who, after completing 2-7 visits in their \
 		first 3 months in care, complete more visits in subsequent months.
 	|
 
-"From1-HighD"= INTEG (
-	"From1-PL3mo into High D"-"From1-PL3mo Ending High D",
+"From Starters-HighD"= INTEG (
+	From Starters into High D-From Starters Ending High D,
 		0)
-	~	pt
+	~	pts
 	~	The upper quartile of patients who, after completing only 1 visit in their \
 		first 3 months in care, complete more visits in subsequent months.
 	|
 
-"From1-MidD"= INTEG (
-	"From1-PL3mo into Mid D"-"From1-+PLmo Ending Mid D",
+"From Starters-MidD"= INTEG (
+	From Starters into Mid D-From Starters Ending Mid D,
 		0)
-	~	pt
+	~	pts
 	~	The inner two quartiles of patients who, after completing only 1 visit in \
 		their first 3 months in care, complete more visits in subsequent months.
 	|
 
-"Median Time in Visit 2-7-n-More>3mo"=
+Initiators Who Return Duration=
 	11
-	~	Week
+	~	wk
 	~	Engagement time for patients who only complete 2-7 visits in their first \
 		three months, but who will complete more visits after their first three \
 		months.
 	|
 
-Ending 1=
+Ending First Visit=
 	Patients in First Visit/Median Time in Visit 1
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients completing their first visit in psychotherapy.
 	|
 
 "Continuing Treatment Rate (After 3 Months) from Visit 2 to 7"=
-	MAX("<3mo Visit 2-7-n-More>3mo"/"Median Time in Visit 2-7-n-More>3mo",0)
-	~	pt/Week
+	MAX(Initiators who will Return/Initiators Who Return Duration,0)
+	~	pts/wk
 	~	Rate of patients ending their 2-7th visit, who will go on to complete less \
 		than 8 visits in their first 3 months. It is constrained from going below \
 		zero.
 	|
 
-Ending First 3months of Psychotherapy=
+Ending After 8 or More Visits Rate=
 	MAX(
 	
-	ZIDZ(Patients in Over 7 Visits, Median Time in Visit 8PL)
+	ZIDZ(Patients in Over 7 Visits, Completers Duration)
 	
 	,0)
-	~	pt/Week
+	~	pts/wk
 	~	Rate of patients ending their 8th visit, who will complete 8 or more \
 		visits in their first 3 months.  This is also known as the "completion \
 		rate," i.e., those patients receiving a full, timely dose of \
@@ -2306,9 +2308,9 @@ Ending First 3months of Psychotherapy=
 
 "Frequency <3mo - 2-7Visits-n-More>3mo"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C10')
-	~	appt/(Week*pt)
-	~	The average number of appointments per patient per week, estimated from \
-		the mean of all individual patients' counts of completed appointments that \
+	~	appt/(wk*pts)
+	~	The average number of appointments per patient per wk, estimated from the \
+		mean of all individual patients' counts of completed appointments that \
 		meet the time criteria defining this stock and their time to complete that \
 		subset of their appointments (i.e., the date difference between their last \
 		completed appointment and their first).
@@ -2316,9 +2318,9 @@ Ending First 3months of Psychotherapy=
 
 "Frequency <3mo - 1Visit"=
 	GET DIRECT CONSTANTS('ModelParameters.xlsx','PSYParams','C8')
-	~	appt/(Week*pt)
-	~	Set to 1.1 visits / week, because a minority of people get more than one \
-		visit in their first week.
+	~	appt/(wk*pts)
+	~	Set to 1.1 visits / wk, because a minority of people get more than one \
+		visit in their first wk.
 	|
 
 ********************************************************
@@ -2328,23 +2330,23 @@ Ending First 3months of Psychotherapy=
 	|
 
 FINAL TIME  = 104
-	~	Week
+	~	wk
 	~	The final time for the simulation.
 	|
 
-INITIAL TIME  = -500
-	~	Week
+INITIAL TIME  = -1000
+	~	wk
 	~	The initial time for the simulation.
 	|
 
 SAVEPER  = 
         TIME STEP
-	~	Week [0,?]
+	~	wk [0,?]
 	~	The frequency with which output is stored.
 	|
 
 TIME STEP  = 0.0625
-	~	Week [0,?]
+	~	wk [0,?]
 	~	The time step for the simulation.
 	|
 
@@ -2352,56 +2354,56 @@ TIME STEP  = 0.0625
 V300  Do not put anything below this section - it will be ignored
 *Interface
 $192-192-192,0,Meiryo|10||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,70,0
-12,1,2493630,308,-3,80,20,3,124,0,0,0,0,0,0
-"User-defined Appointment Supply",0,20,1
-12,2,5638034,309,72,80,20,3,124,0,0,0,0,0,0
-Additional Appt Supply for New Patients,0,10,1
-12,3,4261842,239,592,80,20,3,124,0,0,0,0,0,0
-"User-defined %2-7-n-Done",-0.05,1,0.05
-12,4,3868460,250,712,80,20,3,124,0,0,0,0,0,0
-"User-defined %2-7-n-More<3mo",-0.05,1,0.05
-12,5,3345458,258,274,80,20,3,124,0,0,0,0,0,0
-"User-defined %Visit1<3mo and More",-0.05,1,0.05
-12,6,3017750,238,844,80,20,3,124,0,0,0,0,0,0
-"User-defined %Visit8PL-n-Done",-0.05,1,0.05
-12,7,0,285,147,158,23,8,135,0,24,-1,0,0,0,-1--1--1,0-0-0,|12|U|0-0-0
+12,1,2493558,308,70,80,20,3,124,0,0,0,0,0,0
+User defined Appointment Supply,0,20,1
+12,2,2165974,309,145,80,20,3,124,0,0,0,0,0,0
+Additional Appointments Available to New Patients,0,10,1
+12,3,2297048,239,665,80,20,3,124,0,0,0,0,0,0
+"User-defined Initiators Who Quit Early %",-0.05,1,0.05
+12,4,2166128,250,785,80,20,3,124,0,0,0,0,0,0
+"User-defined Initiators Who Complete %",-0.05,1,0.05
+12,5,2297098,258,347,80,20,3,124,0,0,0,0,0,0
+"User-defined Starters Who Return Later %",-0.05,1,0.05
+12,6,2297410,238,917,80,20,3,124,0,0,0,0,0,0
+"User-defined Completers who Graduate %",-0.05,1,0.05
+12,7,0,285,220,158,23,8,135,0,24,-1,0,0,0,-1--1--1,0-0-0,|12|U|0-0-0
 Engagement Pattern Experiments:
-12,8,0,234,-46,93,17,8,135,0,24,-1,0,0,0,-1--1--1,0-0-0,|12|U|0-0-0
+12,8,0,234,27,93,17,8,135,0,24,-1,0,0,0,-1--1--1,0-0-0,|12|U|0-0-0
 Supply Experiments:
-12,9,0,532,722,166,40,8,135,0,0,-1,0,0,0
+12,9,0,532,795,166,40,8,135,0,0,-1,0,0,0
 For patients who complete 2-7 visits in their first 3 months, what percent go on to complete even more visits in the first 3 months? = Pts who will receive a full, timely dose = "Completers"
-12,10,0,527,457,155,50,8,135,0,0,-1,0,0,0
+12,10,0,527,530,155,50,8,135,0,0,-1,0,0,0
 For patients who complete their first appointment, what percent go on to complete 2-7 visits in the first 3 months? = Pts who complete more than 1 visit in first 3 months = "Initiators"
-12,11,0,521,596,166,40,8,135,0,0,-1,0,0,0
+12,11,0,521,669,166,40,8,135,0,0,-1,0,0,0
 For patients who receive 2-7 visits in first 3 months, what percent never return to care? = Pts who don't receive a full dose = "Initiators who quit" = opposite of "Initiators who Return Later"
-12,12,0,516,278,141,40,8,135,0,0,-1,0,0,0
+12,12,0,516,351,141,40,8,135,0,0,-1,0,0,0
 For patients who complete ONLY 1 visit in first 3 months, what percent of them have more visits in subsequent months=  "One visit and More Later"
-12,13,0,531,853,148,40,8,135,0,0,-1,0,0,0
+12,13,0,531,926,148,40,8,135,0,0,-1,0,0,0
 For patients who have completed 8+ visits in first 3 months, what percent stop then = Pts who stop coming after receiving timely full dose = "Graduators"
-12,14,3278874,245,446,80,20,3,252,0,0,0,0,0,0
-"User-defined % Go on to 2-7 in <3mo",-0.05,1,0.05
-12,15,17959904,1014,239,292,276,3,188,0,0,1,0,0,0
+12,14,2231522,245,519,80,20,3,252,0,0,0,0,0,0
+"User-defined Starters Who Initiate %",-0.05,1,0.05
+12,15,2100598,1014,312,292,276,3,188,0,0,1,0,0,0
 BehaviorOverTime
-12,16,0,416,204,271,11,0,135,0,0,-1,0,0,0
+12,16,0,416,277,271,11,0,135,0,0,-1,0,0,0
 "Completers" = Pts who receive 8+ visits within first 3 months, and then stop coming
-12,17,2230632,1251,792,529,266,3,188,0,0,1,0,0,0
+12,17,0,1251,865,529,266,3,188,0,0,1,0,0,0
 Supply_Used
-12,18,0,333,185,186,11,0,135,0,0,-1,0,0,0
+12,18,0,333,258,186,11,0,135,0,0,-1,0,0,0
 "Initiators" = Pts who receive >1 visit within first 3 months
-12,19,0,412,344,230,29,8,135,0,16,-1,0,0,0,-1--1--1,0-0-0,|10|I|0-0-0
+12,19,0,412,417,230,29,8,135,0,16,-1,0,0,0,-1--1--1,0-0-0,|10|I|0-0-0
 0% implies that the clinic will not schedule these patients for any appointments after the first 3 month window = no second chances
-12,20,0,416,925,243,34,8,135,0,16,-1,0,0,0,0-0-0,0-0-0,|10|I|0-0-0
+12,20,0,416,998,243,34,8,135,0,16,-1,0,0,0,0-0-0,0-0-0,|10|I|0-0-0
 100% implies that the clinic will not schedule these patients for any visits after the first 3 month window = everyone who completes, graduates
-12,21,0,831,1079,219,11,0,135,0,16,-1,0,0,0,-1--1--1,0-0-0,|10|I|0-0-0
+12,21,0,831,1152,219,11,0,135,0,16,-1,0,0,0,-1--1--1,0-0-0,|10|I|0-0-0
 Initial RVI and engagement duration are estimated from team's data.
-12,22,0,379,166,237,11,0,135,0,0,-1,0,0,0
+12,22,0,379,239,237,11,0,135,0,0,-1,0,0,0
 All % are constrained to be between 0 and 100%, regardless of use input.
-12,23,2165470,1548,239,231,276,3,188,0,0,1,0,0,0
+12,23,2100594,1548,312,231,276,3,188,0,0,1,0,0,0
 Performance_Measures_Overview
-12,24,3148760,422,993,80,20,3,124,0,0,0,0,0,0
-"Percent Change Duration of Pts in Care >3mo",-0.75,2,0.25
-12,25,3214216,422,1070,80,20,3,124,0,0,0,0,0,0
-"Percent Change RVI of Patients in Care >3mo",-0.75,2,0.25
+12,24,2035060,422,1066,80,20,3,124,0,0,0,0,0,0
+Change in Engagement Time of Patients Past 3 Months,-0.75,2,0.25
+12,25,3673368,422,1143,80,20,3,124,0,0,0,0,0,0
+Change in RVI of Patient's Past 3 Months,-0.75,2,0.25
 \\\---/// Sketch information - do not modify anything except names
 V300  Do not put anything below this section - it will be ignored
 *Quality Details
@@ -2418,1249 +2420,1137 @@ OUD
 V300  Do not put anything below this section - it will be ignored
 *Supply Used
 $192-192-192,0,Meiryo|10||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,70,0
-10,1,Appointment Supply,361,413,44,20,8,3,0,0,0,0,0,0
-10,2,Appointments Available for New Patients,468,355,79,20,8,3,0,0,0,0,0,0
-10,3,"Supply Used by Pts >3mo",511,504,63,20,8,3,0,0,0,0,0,0
-1,4,1,2,0,0,0,0,0,64,0,-1--1--1,,1|(407,387)|
-10,5,"Frequency <3mo - 1Visit",894,283,57,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,6,5,31,0,0,0,0,0,64,0,-1--1--1,,1|(834,317)|
-10,7,"Frequency <3mo - 2-7Visits-n-More>3mo",1107,291,76,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,8,7,30,0,0,0,0,0,64,0,-1--1--1,,1|(944,368)|
-10,9,"Frequency <3mo - 8-12 Visits",1208,619,62,20,8,3,0,0,0,0,0,0
-1,10,9,32,1,0,0,0,0,64,0,-1--1--1,,1|(995,577)|
-10,11,Patients in First Visit,896,330,56,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-10,12,"<3mo Visit 2-7-n-More>3mo",1092,335,48,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,13,Patients in Over 7 Visits,1200,667,60,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,14,11,31,0,0,0,0,0,128,0,-1--1--1,,1|(833,343)|
-1,15,12,30,0,0,0,0,0,128,0,-1--1--1,,1|(940,390)|
-1,16,13,32,1,0,0,0,0,128,0,-1--1--1,,1|(1002,606)|
-10,17,"Frequency >3mo - 1Visit-LowD",679,782,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,18,"Frequency >3mo - 2-7Visits-LowD",954,780,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,19,"Frequency >3mo - 8-12Visits-LowD",1250,778,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,20,"Frequency >3mo - 1Visit-MidD",691,871,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,21,"Frequency >3mo - 2-7Visits-MidD",949,880,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,22,"Frequency >3mo - 8-12Visits-MidD",1239,876,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,23,"Frequency >3mo - 1Visit-HighD",699,970,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,24,"Frequency >3mo - 2-7Visits-HighD",953,972,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,25,"Frequency >3mo - 8-12Visits-HighD",1241,979,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,26,"<3mo Visit 2-7 -n-done",1087,449,55,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,27,"<3mo Visit 2-7-n-More<3mo",1093,550,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,28,"Frequency <3mo - 2-7Visits-n-done",1090,415,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,29,"Frequency <3mo - 2-7Visits-n-More<3mo",1091,509,76,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,30,"<3mo - Supply Used by Visit 2-7",770,453,68,20,8,3,0,0,0,0,0,0
-10,31,"<3mo - Supply Used by Visit1",763,360,50,20,8,3,0,0,0,0,0,0
-10,32,"<3mo - Supply Used by Visit 8PL",763,532,68,20,8,3,0,0,0,0,0,0
-1,33,28,30,0,0,0,0,0,64,0,-1--1--1,,1|(939,432)|
-1,34,26,30,0,0,0,0,0,64,0,-1--1--1,,1|(941,450)|
-1,35,29,30,0,0,0,0,0,64,0,-1--1--1,,1|(933,481)|
-1,36,27,30,0,0,0,0,0,64,0,-1--1--1,,1|(938,504)|
-1,37,31,40,0,0,0,0,0,64,0,-1--1--1,,1|(694,410)|
-1,38,30,40,0,0,0,0,0,64,0,-1--1--1,,1|(696,460)|
-1,39,32,40,0,0,0,0,0,64,0,-1--1--1,,1|(695,503)|
-10,40,"Supply Used by Pts <3mo",615,470,63,20,8,3,0,0,0,0,0,0
-1,41,29,9,1,0,0,0,0,64,0,-1--1--1,,1|(1206,564)|
-1,42,3,83,0,0,0,0,0,64,0,-1--1--1,,1|(512,463)|
-10,43,">3mo - Supply Used by FromVisit1",397,848,68,20,8,3,0,0,0,0,0,0
-1,44,23,43,0,0,0,0,0,64,0,-1--1--1,,1|(554,911)|
-1,45,17,43,0,0,0,0,0,64,0,-1--1--1,,1|(547,812)|
-1,46,20,43,0,0,0,0,0,64,0,-1--1--1,,1|(553,860)|
-10,47,"From1-HighD",684,999,55,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,48,47,43,0,0,0,0,0,64,0,-1--1--1,,1|(555,931)|
-10,49,"From1-LowD",678,813,53,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,50,49,43,0,0,0,0,0,64,0,-1--1--1,,1|(551,828)|
-10,51,"From1-MidD",685,901,51,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,52,51,43,0,0,0,0,0,64,0,-1--1--1,,1|(556,877)|
-10,53,">3mo - Supply Used by FromVisit2-7",817,876,68,20,8,3,0,0,0,0,0,0
-10,54,">3mo - Supply Used by FromVisit8PL",1125,881,68,20,8,3,0,0,0,0,0,0
-1,55,24,53,0,0,0,0,0,64,0,-1--1--1,,1|(890,928)|
-1,56,18,53,0,0,0,0,0,64,0,-1--1--1,,1|(891,824)|
-1,57,21,53,0,0,0,0,0,64,0,-1--1--1,,1|(892,881)|
-10,58,"From2-7-HighD",949,1000,63,10,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,59,58,53,0,0,0,0,0,64,0,-1--1--1,,1|(893,947)|
-10,60,"From2-7-LowD",955,809,61,10,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,61,60,53,0,0,0,0,0,64,0,-1--1--1,,1|(902,834)|
-10,62,"From2-7-MidD",941,909,58,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,63,62,53,0,0,0,0,0,64,0,-1--1--1,,1|(899,897)|
-1,64,25,54,0,0,0,0,0,64,0,-1--1--1,,1|(1188,934)|
-1,65,19,54,0,0,0,0,0,64,0,-1--1--1,,1|(1192,825)|
-1,66,22,54,0,0,0,0,0,64,0,-1--1--1,,1|(1191,877)|
-10,67,"From8PL-HighD",1241,1011,64,10,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,68,67,54,0,0,0,0,0,64,0,-1--1--1,,1|(1192,956)|
-10,69,"From8PL-LowD",1249,807,62,10,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,70,69,54,0,0,0,0,0,64,0,-1--1--1,,1|(1201,835)|
-10,71,"From8PL-MidD",1238,907,59,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,72,71,54,0,0,0,0,0,64,0,-1--1--1,,1|(1198,897)|
-1,73,43,3,1,0,0,0,0,128,0,-1--1--1,,1|(527,688)|
-1,74,53,3,1,0,0,0,0,128,0,-1--1--1,,1|(714,676)|
-1,75,54,3,1,0,0,0,0,128,0,-1--1--1,,1|(878,658)|
-12,76,0,616,688,61,61,6,135,0,16,-1,0,0,0,-1--1--1,0-0-0,|10|I|0-0-0
+10,1,Appointment Supply,361,52,44,20,8,3,0,0,0,0,0,0
+10,2,Appointments Available for New Patients,468,-6,79,20,8,3,0,0,0,0,0,0
+10,3,"Supply Used by Pts >3mo",511,143,63,20,8,3,0,0,0,0,0,0
+1,4,1,2,0,0,0,0,0,64,0,-1--1--1,,1|(407,26)|
+10,5,"Frequency <3mo - 1Visit",894,-78,57,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,6,5,31,0,0,0,0,0,64,0,-1--1--1,,1|(834,-43)|
+10,7,"Frequency <3mo - 2-7Visits-n-More>3mo",1107,-70,76,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,8,7,30,0,0,0,0,0,64,0,-1--1--1,,1|(944,7)|
+10,9,"Frequency <3mo - 8-12 Visits",1208,258,62,20,8,3,0,0,0,0,0,0
+1,10,9,32,1,0,0,0,0,64,0,-1--1--1,,1|(987,214)|
+10,11,Patients in First Visit,896,-31,56,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,12,Initiators who will Return,1092,-26,48,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+10,13,Patients in Over 7 Visits,1200,306,60,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,14,11,31,0,0,0,0,0,128,0,-1--1--1,,1|(833,-17)|
+1,15,12,30,0,0,0,0,0,128,0,-1--1--1,,1|(939,29)|
+1,16,13,32,1,0,0,0,0,128,0,-1--1--1,,1|(996,242)|
+10,17,"Frequency >3mo - 1Visit-LowD",509,418,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,18,"Frequency >3mo - 2-7Visits-LowD",954,419,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,19,"Frequency >3mo - 8-12Visits-LowD",1514,391,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,20,"Frequency >3mo - 1Visit-MidD",521,507,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,21,"Frequency >3mo - 2-7Visits-MidD",949,519,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,22,"Frequency >3mo - 8-12Visits-MidD",1503,489,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,23,"Frequency >3mo - 1Visit-HighD",529,606,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,24,"Frequency >3mo - 2-7Visits-HighD",953,611,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,25,"Frequency >3mo - 8-12Visits-HighD",1505,592,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,26,Initiators who will Quit,1087,88,55,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+10,27,Initiators who will Continue,1093,189,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+10,28,"Frequency <3mo - 2-7Visits-n-done",1090,54,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,29,"Frequency <3mo - 2-7Visits-n-More<3mo",1091,148,76,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,30,Supply Used by Initiators,770,92,51,20,8,3,0,0,0,0,0,0
+10,31,Supply Used by New Patients,763,-1,51,20,8,3,0,0,0,0,0,0
+10,32,Supply Used by Completers,763,171,51,20,8,3,0,0,0,0,0,0
+1,33,28,30,0,0,0,0,0,64,0,-1--1--1,,1|(931,72)|
+1,34,26,30,0,0,0,0,0,64,0,-1--1--1,,1|(933,89)|
+1,35,29,30,0,0,0,0,0,64,0,-1--1--1,,1|(924,118)|
+1,36,27,30,0,0,0,0,0,64,0,-1--1--1,,1|(931,140)|
+1,37,31,40,0,0,0,0,0,64,0,-1--1--1,,1|(694,49)|
+1,38,30,40,0,0,0,0,0,64,0,-1--1--1,,1|(705,98)|
+1,39,32,40,0,0,0,0,0,64,0,-1--1--1,,1|(695,142)|
+10,40,"Supply Used by Pts <3mo",615,109,63,20,8,3,0,0,0,0,0,0
+1,41,29,9,1,0,0,0,0,64,0,-1--1--1,,1|(1206,203)|
+1,42,3,83,0,0,0,0,0,64,0,-1--1--1,,1|(512,102)|
+10,43,Supply Used by New Patients who Return,227,484,68,20,8,3,0,0,0,0,0,0
+1,44,23,43,0,0,0,0,0,64,0,-1--1--1,,1|(384,547)|
+1,45,17,43,0,0,0,0,0,64,0,-1--1--1,,1|(377,448)|
+1,46,20,43,0,0,0,0,0,64,0,-1--1--1,,1|(383,496)|
+10,47,"From Starters-HighD",514,635,55,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,48,47,43,0,0,0,0,0,64,0,-1--1--1,,1|(385,567)|
+10,49,"From Starters-LowD",508,449,53,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,50,49,43,0,0,0,0,0,64,0,-1--1--1,,1|(381,464)|
+10,51,"From Starters-MidD",515,537,51,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,52,51,43,0,0,0,0,0,64,0,-1--1--1,,1|(386,513)|
+10,53,Supply Used by Initiators who Return,817,515,71,20,8,3,0,0,0,0,0,0
+10,54,Supply Used by Completers who Continue,1334,510,55,30,8,3,0,0,0,0,0,0
+1,55,24,53,0,0,0,0,0,64,0,-1--1--1,,1|(890,567)|
+1,56,18,53,0,0,0,0,0,64,0,-1--1--1,,1|(891,463)|
+1,57,21,53,0,0,0,0,0,64,0,-1--1--1,,1|(894,517)|
+10,58,"From Initiators-HighD",949,639,63,10,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,59,58,53,0,0,0,0,0,64,0,-1--1--1,,1|(893,586)|
+10,60,"From Initiators-LowD",955,448,61,10,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,61,60,53,0,0,0,0,0,64,0,-1--1--1,,1|(902,473)|
+10,62,"From Initiators-MidD",941,548,58,11,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,63,62,53,0,0,0,0,0,64,0,-1--1--1,,1|(900,537)|
+1,64,25,54,0,0,0,0,0,64,0,-1--1--1,,1|(1432,557)|
+1,65,19,54,0,0,0,0,0,64,0,-1--1--1,,1|(1437,441)|
+1,66,22,54,0,0,0,0,0,64,0,-1--1--1,,1|(1421,498)|
+10,67,"From Completers-HighD",1505,624,64,10,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,68,67,54,0,0,0,0,0,64,0,-1--1--1,,1|(1440,580)|
+10,69,"From Completers-LowD",1513,420,62,10,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,70,69,54,0,0,0,0,0,64,0,-1--1--1,,1|(1447,452)|
+10,71,"From Completers-MidD",1502,520,59,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,72,71,54,0,0,0,0,0,64,0,-1--1--1,,1|(1423,515)|
+1,73,43,3,1,0,0,0,0,128,0,-1--1--1,,1|(527,327)|
+1,74,53,3,1,0,0,0,0,128,0,-1--1--1,,1|(714,315)|
+1,75,54,3,1,0,0,0,0,128,0,-1--1--1,,1|(999,256)|
+12,76,0,446,324,61,61,6,135,0,16,-1,0,0,0,-1--1--1,0-0-0,|10|I|0-0-0
 Frequency data only include visits that happened, not visits that were missed
-10,77,"User-defined Appointment Supply",359,519,68,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,78,77,1,0,0,0,0,0,128,0,-1--1--1,,1|(359,472)|
-10,79,Baseline Appointment Supply,262,455,48,26,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,80,79,1,0,0,0,0,0,128,0,-1--1--1,,1|(307,436)|
-10,81,Additional Appt Supply for New Patients,602,300,75,20,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,82,81,2,0,0,0,0,0,128,0,-1--1--1,,1|(541,324)|
-10,83,Appointments Used by Existing Patients,515,409,75,20,8,3,0,0,0,0,0,0
-1,84,40,83,0,0,0,0,0,128,0,-1--1--1,,1|(571,443)|
-1,85,83,2,0,0,0,0,0,128,0,-1--1--1,,1|(496,387)|
-10,86,"Percent Change RVI of Patients in Care >3mo",831,1106,77,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,87,86,43,1,0,0,0,0,128,0,-1--1--1,,1|(577,1012)|
-1,88,86,53,1,0,0,0,0,128,0,-1--1--1,,1|(849,993)|
-1,89,86,54,1,0,0,0,0,128,0,-1--1--1,,1|(1020,1034)|
-10,90,Bars E3,820,234,26,11,8,3,1,0,0,0,0,0
-1,91,5,90,0,1,0,0,0,128,0,-1--1--1,,1|(855,257)|
-10,92,Median Time in Visit 1,934,237,45,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,93,92,90,0,1,0,0,0,128,0,-1--1--1,,1|(874,235)|
-10,94,Bars E4,438,1101,26,11,8,3,1,0,0,0,0,0
-1,95,17,94,0,1,0,0,0,128,0,-1--1--1,,1|(559,939)|
-1,96,20,94,0,1,0,0,0,128,0,-1--1--1,,1|(564,985)|
-1,97,23,94,0,1,0,0,0,128,0,-1--1--1,,1|(565,1036)|
-10,98,"From1-PL3mo Median Time in Lower Q",330,1047,67,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,99,98,94,0,1,0,0,0,64,0,-1--1--1,,1|(386,1075)|
-10,100,"PL3mo % starting LowD",936,1345,65,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,101,100,94,0,1,0,0,0,64,0,-1--1--1,,1|(684,1221)|
-10,102,"From1-PL3mo Median Time in Mid Qs",322,1119,67,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,103,102,94,0,1,0,0,0,64,0,-1--1--1,,1|(393,1108)|
-10,104,"From1-PL3mo Median Time in Upper Q",322,1174,67,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,105,104,94,0,1,0,0,0,64,0,-1--1--1,,1|(380,1136)|
-10,106,"PL3mo % starting HighD",929,1449,65,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,107,106,94,0,1,0,0,0,64,0,-1--1--1,,1|(682,1274)|
-10,108,"PL3mo % starting MidD",927,1400,65,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,109,108,94,0,1,0,0,0,64,0,-1--1--1,,1|(680,1249)|
-10,110,Bars E5,1375,421,26,11,8,3,1,0,0,0,0,0
-1,111,28,110,0,1,0,0,0,128,0,-1--1--1,,1|(1243,417)|
-10,112,"Median Time in Visit 2-7-n-Done",1408,376,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,113,112,110,0,1,0,0,0,64,0,-1--1--1,,1|(1392,397)|
-10,114,Bars E6,1367,268,26,11,8,3,1,0,0,0,0,0
-1,115,7,114,0,1,0,0,0,128,0,-1--1--1,,1|(1255,278)|
-10,116,"Bars E6 >3mo",1020,1165,47,11,8,3,1,0,0,0,0,0
-1,117,18,116,0,1,0,0,0,128,0,-1--1--1,,1|(986,970)|
-1,118,21,116,0,1,0,0,0,128,0,-1--1--1,,1|(983,1020)|
-1,119,24,116,0,1,0,0,0,128,0,-1--1--1,,1|(985,1066)|
-10,120,"From2-7-PL3mo Median Time in Lower Q",844,1166,74,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,121,120,116,0,1,0,0,0,64,0,-1--1--1,,1|(938,1165)|
-10,122,"From2-7-PL3mo Median Time in Mid Qs",861,1210,74,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,123,122,116,0,1,0,0,0,64,0,-1--1--1,,1|(949,1184)|
-10,124,"From2-7-PL3mo Median Time in Upper Q",880,1252,74,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,125,124,116,0,1,0,0,0,64,0,-1--1--1,,1|(951,1207)|
-10,126,"Median Time in Visit 2-7-n-More>3mo",1416,228,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,127,126,114,0,1,0,0,0,64,0,-1--1--1,,1|(1391,248)|
-10,128,Bars E7,1377,538,26,11,8,3,1,0,0,0,0,0
-1,129,29,128,0,1,0,0,0,128,0,-1--1--1,,1|(1252,524)|
-10,130,"Median Time in Visit 2-7-More<3mo",1393,484,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,131,130,128,0,1,0,0,0,64,0,-1--1--1,,1|(1386,508)|
-10,132,Bars E8,1371,610,26,11,8,3,1,0,0,0,0,0
-1,133,9,132,0,1,0,0,0,128,0,-1--1--1,,1|(1300,613)|
-10,134,Median Time in Visit 8PL,1393,575,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,135,134,132,0,1,0,0,0,64,0,-1--1--1,,1|(1383,592)|
-10,136,Bars E9,1367,1112,26,11,8,3,1,0,0,0,0,0
-1,137,25,136,0,1,0,0,0,128,0,-1--1--1,,1|(1302,1044)|
-1,138,22,136,0,1,0,0,0,128,0,-1--1--1,,1|(1301,992)|
-1,139,19,136,0,1,0,0,0,128,0,-1--1--1,,1|(1307,942)|
-1,140,100,116,0,1,0,0,0,128,0,-1--1--1,,1|(976,1256)|
-1,141,108,116,0,1,0,0,0,128,0,-1--1--1,,1|(971,1284)|
-1,142,106,116,0,1,0,0,0,128,0,-1--1--1,,1|(973,1309)|
-1,143,100,136,0,1,0,0,0,128,0,-1--1--1,,1|(1152,1227)|
-1,144,108,136,0,1,0,0,0,128,0,-1--1--1,,1|(1147,1255)|
-1,145,106,136,0,1,0,0,0,128,0,-1--1--1,,1|(1147,1280)|
-10,146,"From8PL-PL3mo Median Time in Lower Q",1526,1050,75,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,147,146,136,0,1,0,0,0,64,0,-1--1--1,,1|(1440,1083)|
-10,148,"From8PL-PL3mo MedianTime in Mid Qs",1521,1124,75,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,149,148,136,0,1,0,0,0,64,0,-1--1--1,,1|(1426,1117)|
-10,150,"From8PL-PL3mo Median Time in Upper Q",1508,1185,75,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,151,150,136,0,1,0,0,0,64,0,-1--1--1,,1|(1435,1147)|
-1,152,86,94,0,1,0,0,0,64,0,-1--1--1,,1|(615,1103)|
-1,153,86,116,0,1,0,0,0,64,0,-1--1--1,,1|(932,1137)|
-1,154,86,136,0,1,0,0,0,64,0,-1--1--1,,1|(1117,1108)|
-10,155,"Bars E4-Final",443,1248,44,11,8,3,1,0,0,0,0,0
-1,156,94,155,0,1,0,0,0,128,0,-1--1--1,,1|(439,1167)|
-10,157,FINAL TIME,443,1279,49,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,158,157,155,0,1,0,0,0,64,0,-1--1--1,,1|(443,1270)|
-10,159,Time,443,1279,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,160,159,155,0,1,0,0,0,64,0,-1--1--1,,1|(443,1270)|
-10,161,"Bars E4-Initial",548,1255,47,11,8,3,1,0,0,0,0,0
-1,162,94,161,0,1,0,0,0,128,0,-1--1--1,,1|(488,1172)|
-10,163,INITIAL TIME,548,1286,55,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,164,163,161,0,1,0,0,0,64,0,-1--1--1,,1|(548,1277)|
-10,165,Time,548,1286,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,166,165,161,0,1,0,0,0,64,0,-1--1--1,,1|(548,1277)|
-10,167,"Bars E6 >3mo-Final",1113,1119,39,20,8,3,1,0,0,0,0,0
-10,168,"Bars E6 >3mo-Initial",1125,1193,42,20,8,3,1,0,0,0,0,0
-10,169,"Bars E9-Final",1356,1247,44,11,8,3,1,0,0,0,0,0
-10,170,"Bars E9-Initial",1496,1250,47,11,8,3,1,0,0,0,0,0
-1,171,116,167,0,1,0,0,0,64,0,-1--1--1,,1|(1051,1149)|
-10,172,FINAL TIME,1113,1159,49,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,173,172,167,0,1,0,0,0,64,0,-1--1--1,,1|(1113,1150)|
-10,174,Time,1113,1159,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,175,174,167,0,1,0,0,0,64,0,-1--1--1,,1|(1113,1150)|
-1,176,116,168,0,1,0,0,0,64,0,-1--1--1,,1|(1065,1176)|
-10,177,INITIAL TIME,1125,1233,55,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,178,177,168,0,1,0,0,0,64,0,-1--1--1,,1|(1125,1224)|
-10,179,Time,1125,1233,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,180,179,168,0,1,0,0,0,64,0,-1--1--1,,1|(1125,1224)|
-1,181,136,170,0,1,0,0,0,64,0,-1--1--1,,1|(1426,1175)|
-10,182,INITIAL TIME,1496,1281,55,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,183,182,170,0,1,0,0,0,64,0,-1--1--1,,1|(1496,1272)|
-10,184,Time,1496,1281,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,185,184,170,0,1,0,0,0,64,0,-1--1--1,,1|(1496,1272)|
-1,186,136,169,0,1,0,0,0,64,0,-1--1--1,,1|(1362,1172)|
-10,187,FINAL TIME,1329,1311,49,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,188,187,169,0,1,0,0,0,64,0,-1--1--1,,1|(1339,1285)|
-10,189,Time,1356,1278,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,190,189,169,0,1,0,0,0,64,0,-1--1--1,,1|(1356,1269)|
-10,191,Experiment Week,211,255,58,11,8,3,1,0,0,0,0,0
-1,192,191,1,0,1,0,0,0,128,0,-1--1--1,,1|(276,324)|
-10,193,Time,273,390,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,194,193,1,0,1,0,0,0,64,0,-1--1--1,,1|(302,397)|
-1,195,191,2,0,1,0,0,0,64,0,-1--1--1,,1|(320,297)|
-1,196,191,43,0,1,0,0,0,64,0,-1--1--1,,1|(299,540)|
-1,197,191,53,0,1,0,0,0,128,0,-1--1--1,,1|(504,555)|
-1,198,191,54,0,1,0,0,0,128,0,-1--1--1,,1|(655,559)|
-10,199,Supply Available for New Pts who can start 2nd visit,425,253,87,20,8,3,0,0,0,0,0,0
-1,200,81,199,0,0,0,0,0,64,0,-1--1--1,,1|(520,278)|
-1,201,1,199,0,0,0,0,0,64,0,-1--1--1,,1|(390,339)|
-1,202,191,199,0,1,0,0,0,64,0,-1--1--1,,1|(296,254)|
-1,203,83,199,0,0,0,0,0,64,0,-1--1--1,,1|(473,337)|
-10,204,Appointments in Psychotherapy,699,182,55,20,8,3,0,0,0,0,0,0
-10,205,Booking Rate,575,183,45,11,8,3,0,0,0,0,0,0
-10,206,Completing Rate,823,192,55,11,8,3,0,0,0,0,0,0
-1,207,1,205,0,0,0,0,0,128,0,-1--1--1,,1|(466,298)|
-1,208,81,205,0,0,0,0,0,128,0,-1--1--1,,1|(589,243)|
-10,209,Total Pts in Psych,652,243,43,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-10,210,Pts per Appt,1062,151,51,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,211,209,204,0,0,0,0,0,128,0,-1--1--1,,1|(670,218)|
-1,212,210,204,1,0,0,0,0,128,0,-1--1--1,,1|(883,146)|
-1,213,191,94,0,1,0,0,0,64,0,-1--1--1,,1|(322,671)|
-1,214,191,116,0,1,0,0,0,64,0,-1--1--1,,1|(610,704)|
-1,215,191,136,0,1,0,0,0,64,0,-1--1--1,,1|(782,679)|
-10,216,Initiators who Complete,1255,444,46,20,8,3,1,0,0,0,0,0
-1,217,29,216,0,1,0,0,0,64,0,-1--1--1,,1|(1168,478)|
-10,218,Initiators who Quit Early,1262,329,46,20,8,3,1,0,0,0,0,0
-1,219,28,218,0,1,0,0,0,64,0,-1--1--1,,1|(1169,375)|
-10,220,Completers who Graduate,1296,561,55,20,8,3,1,0,0,0,0,0
-1,221,9,220,0,1,0,0,0,64,0,-1--1--1,,1|(1245,593)|
-1,222,210,216,0,1,0,0,0,128,0,-1--1--1,,1|(1151,287)|
-1,223,210,220,0,1,0,0,0,128,0,-1--1--1,,1|(1172,345)|
-10,224,"From 1 Visit (1st Quartile)",784,729,55,20,8,3,1,0,0,0,0,0
-10,225,"From 1 Visit (Mean)",798,811,40,20,8,3,1,0,0,0,0,0
-10,226,"From 1 Visit (4th Quartile)",780,1038,56,20,8,3,1,0,0,0,0,0
-10,227,"From 2 to 7 Visits (1st Quartile)",1123,728,58,20,8,3,1,0,0,0,0,0
-10,228,"From 2 to 7 Visits (Mean)",1124,830,58,20,8,3,1,0,0,0,0,0
-10,229,"From 2 to 7 Visits (4th Quartile)",1117,1038,58,20,8,3,1,0,0,0,0,0
-10,230,"From 8 or More Visits (1st Quartile)",1394,782,70,20,8,3,1,0,0,0,0,0
-10,231,"From 8 or More Visits (Mean)",1381,882,52,20,8,3,1,0,0,0,0,0
-10,232,"From 8 or More Visits (4th Quartile)",1392,986,70,20,8,3,1,0,0,0,0,0
-1,233,17,224,0,1,0,0,0,128,0,-1--1--1,,1|(724,758)|
-1,234,20,225,0,1,0,0,0,128,0,-1--1--1,,1|(737,844)|
-1,235,23,226,0,1,0,0,0,128,0,-1--1--1,,1|(733,999)|
-1,236,18,227,0,1,0,0,0,128,0,-1--1--1,,1|(1033,755)|
-1,237,21,228,0,1,0,0,0,128,0,-1--1--1,,1|(1031,856)|
-1,238,24,229,0,1,0,0,0,128,0,-1--1--1,,1|(1028,1002)|
-1,239,19,230,0,1,0,0,0,128,0,-1--1--1,,1|(1311,778)|
-1,240,22,231,0,1,0,0,0,128,0,-1--1--1,,1|(1307,878)|
-1,241,25,232,0,1,0,0,0,128,0,-1--1--1,,1|(1305,981)|
-1,242,210,224,0,1,0,0,0,128,0,-1--1--1,,1|(928,429)|
-1,243,210,225,0,1,0,0,0,128,0,-1--1--1,,1|(934,470)|
-1,244,210,226,0,1,0,0,0,128,0,-1--1--1,,1|(924,583)|
-1,245,210,227,0,1,0,0,0,128,0,-1--1--1,,1|(1090,428)|
-1,246,210,228,0,1,0,0,0,128,0,-1--1--1,,1|(1091,479)|
-1,247,210,229,0,1,0,0,0,128,0,-1--1--1,,1|(1088,583)|
-1,248,210,230,0,1,0,0,0,128,0,-1--1--1,,1|(1221,455)|
-1,249,210,231,0,1,0,0,0,128,0,-1--1--1,,1|(1216,505)|
-1,250,210,232,0,1,0,0,0,128,0,-1--1--1,,1|(1222,557)|
-1,251,210,218,0,1,0,0,0,128,0,-1--1--1,,1|(1151,230)|
-1,252,83,206,0,0,0,0,0,128,0,-1--1--1,,1|(669,300)|
+10,77,User defined Appointment Supply,359,158,68,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,78,77,1,0,0,0,0,0,128,0,-1--1--1,,1|(359,111)|
+10,79,"Appointment Supply (75th percentile)",262,94,68,20,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,80,79,1,0,0,0,0,0,128,0,-1--1--1,,1|(306,75)|
+10,81,Additional Appointments Available to New Patients,602,-61,85,20,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,82,81,2,0,0,0,0,0,128,0,-1--1--1,,1|(541,-36)|
+10,83,Appointments Used by Existing Patients,515,48,75,20,8,3,0,0,0,0,0,0
+1,84,40,83,0,0,0,0,0,128,0,-1--1--1,,1|(571,82)|
+1,85,83,2,0,0,0,0,0,128,0,-1--1--1,,1|(496,26)|
+10,86,Change in RVI of Patient's Past 3 Months,755,704,78,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,87,86,43,1,0,0,0,0,128,0,-1--1--1,,1|(389,616)|
+1,88,86,53,1,0,0,0,0,128,0,-1--1--1,,1|(803,618)|
+1,89,86,54,1,0,0,0,0,128,0,-1--1--1,,1|(1108,751)|
+10,90,Bars E3,820,-127,26,11,8,3,1,0,0,0,0,0
+1,91,5,90,0,1,0,0,0,128,0,-1--1--1,,1|(855,-103)|
+10,92,Median Time in Visit 1,934,-124,45,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,93,92,90,0,1,0,0,0,128,0,-1--1--1,,1|(874,-125)|
+10,94,Bars E4,438,740,26,11,8,3,1,0,0,0,0,0
+1,95,17,94,0,1,0,0,0,128,0,-1--1--1,,1|(474,576)|
+1,96,20,94,0,1,0,0,0,128,0,-1--1--1,,1|(479,621)|
+1,97,23,94,0,1,0,0,0,128,0,-1--1--1,,1|(484,671)|
+10,98,From Starters Median Time in Lower Q,160,683,67,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,99,98,94,0,1,0,0,0,64,0,-1--1--1,,1|(312,713)|
+10,100,"Starting LowD %",936,984,65,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,101,100,94,0,1,0,0,0,64,0,-1--1--1,,1|(684,860)|
+10,102,From Starters Median Time in Mid Qs,322,758,67,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,103,102,94,0,1,0,0,0,64,0,-1--1--1,,1|(393,747)|
+10,104,From Starters Median Time in Upper Q,322,813,67,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,105,104,94,0,1,0,0,0,64,0,-1--1--1,,1|(380,775)|
+10,106,"Starting HighD %",929,1088,65,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,107,106,94,0,1,0,0,0,64,0,-1--1--1,,1|(682,913)|
+10,108,"Starting MidD %",927,1039,65,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,109,108,94,0,1,0,0,0,64,0,-1--1--1,,1|(680,888)|
+10,110,Bars E5,1375,60,26,11,8,3,1,0,0,0,0,0
+1,111,28,110,0,1,0,0,0,128,0,-1--1--1,,1|(1243,56)|
+10,112,Initiators Who Quit Early Duration,1408,15,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,113,112,110,0,1,0,0,0,64,0,-1--1--1,,1|(1392,36)|
+10,114,Bars E6,1367,-93,26,11,8,3,1,0,0,0,0,0
+1,115,7,114,0,1,0,0,0,128,0,-1--1--1,,1|(1255,-82)|
+10,116,"Bars E6 >3mo",1020,804,47,11,8,3,1,0,0,0,0,0
+1,117,18,116,0,1,0,0,0,128,0,-1--1--1,,1|(986,609)|
+1,118,21,116,0,1,0,0,0,128,0,-1--1--1,,1|(983,659)|
+1,119,24,116,0,1,0,0,0,128,0,-1--1--1,,1|(985,705)|
+10,120,From Initiators Median Time in Lower Q,844,805,74,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,121,120,116,0,1,0,0,0,64,0,-1--1--1,,1|(938,804)|
+10,122,From Initiators Median Time in Mid Qs,861,849,74,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,123,122,116,0,1,0,0,0,64,0,-1--1--1,,1|(949,823)|
+10,124,From Initiators Median Time in Upper Q,880,891,74,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,125,124,116,0,1,0,0,0,64,0,-1--1--1,,1|(951,846)|
+10,126,Initiators Who Return Duration,1416,-133,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,127,126,114,0,1,0,0,0,64,0,-1--1--1,,1|(1391,-112)|
+10,128,Bars E7,1377,177,26,11,8,3,1,0,0,0,0,0
+1,129,29,128,0,1,0,0,0,128,0,-1--1--1,,1|(1252,163)|
+10,130,Initiators Who Graduate Duration,1393,123,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,131,130,128,0,1,0,0,0,64,0,-1--1--1,,1|(1386,147)|
+10,132,Bars E8,1371,249,26,11,8,3,1,0,0,0,0,0
+1,133,9,132,0,1,0,0,0,128,0,-1--1--1,,1|(1300,252)|
+10,134,Completers Duration,1393,214,60,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,135,134,132,0,1,0,0,0,64,0,-1--1--1,,1|(1383,231)|
+10,136,Bars E9,1367,751,26,11,8,3,1,0,0,0,0,0
+1,137,25,136,0,1,0,0,0,128,0,-1--1--1,,1|(1436,670)|
+1,138,22,136,0,1,0,0,0,128,0,-1--1--1,,1|(1435,618)|
+1,139,19,136,0,1,0,0,0,128,0,-1--1--1,,1|(1441,569)|
+1,140,100,116,0,1,0,0,0,128,0,-1--1--1,,1|(976,895)|
+1,141,108,116,0,1,0,0,0,128,0,-1--1--1,,1|(971,923)|
+1,142,106,116,0,1,0,0,0,128,0,-1--1--1,,1|(973,948)|
+1,143,100,136,0,1,0,0,0,128,0,-1--1--1,,1|(1152,866)|
+1,144,108,136,0,1,0,0,0,128,0,-1--1--1,,1|(1147,894)|
+1,145,106,136,0,1,0,0,0,128,0,-1--1--1,,1|(1147,919)|
+10,146,From Completers Median Time in Lower Q,1526,689,75,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,147,146,136,0,1,0,0,0,64,0,-1--1--1,,1|(1440,722)|
+10,148,From Completers MedianTime in Mid Qs,1521,763,75,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,149,148,136,0,1,0,0,0,64,0,-1--1--1,,1|(1426,756)|
+10,150,From Completers Median Time in Upper Q,1508,824,75,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,151,150,136,0,1,0,0,0,64,0,-1--1--1,,1|(1435,786)|
+1,152,86,94,0,1,0,0,0,64,0,-1--1--1,,1|(577,723)|
+1,153,86,116,0,1,0,0,0,64,0,-1--1--1,,1|(892,756)|
+1,154,86,136,0,1,0,0,0,64,0,-1--1--1,,1|(1080,728)|
+10,155,"Bars E4-Final",443,887,44,11,8,3,1,0,0,0,0,0
+1,156,94,155,0,1,0,0,0,128,0,-1--1--1,,1|(439,806)|
+10,157,FINAL TIME,443,918,49,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,158,157,155,0,1,0,0,0,64,0,-1--1--1,,1|(443,909)|
+10,159,Time,443,918,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,160,159,155,0,1,0,0,0,64,0,-1--1--1,,1|(443,909)|
+10,161,"Bars E4-Initial",548,894,47,11,8,3,1,0,0,0,0,0
+1,162,94,161,0,1,0,0,0,128,0,-1--1--1,,1|(488,811)|
+10,163,INITIAL TIME,548,925,55,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,164,163,161,0,1,0,0,0,64,0,-1--1--1,,1|(548,916)|
+10,165,Time,548,925,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,166,165,161,0,1,0,0,0,64,0,-1--1--1,,1|(548,916)|
+10,167,"Bars E6 >3mo-Final",1113,758,39,20,8,3,1,0,0,0,0,0
+10,168,"Bars E6 >3mo-Initial",1125,832,42,20,8,3,1,0,0,0,0,0
+10,169,"Bars E9-Final",1356,886,44,11,8,3,1,0,0,0,0,0
+10,170,"Bars E9-Initial",1496,889,47,11,8,3,1,0,0,0,0,0
+1,171,116,167,0,1,0,0,0,64,0,-1--1--1,,1|(1051,788)|
+10,172,FINAL TIME,1113,798,49,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,173,172,167,0,1,0,0,0,64,0,-1--1--1,,1|(1113,789)|
+10,174,Time,1113,798,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,175,174,167,0,1,0,0,0,64,0,-1--1--1,,1|(1113,789)|
+1,176,116,168,0,1,0,0,0,64,0,-1--1--1,,1|(1065,815)|
+10,177,INITIAL TIME,1125,872,55,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,178,177,168,0,1,0,0,0,64,0,-1--1--1,,1|(1125,863)|
+10,179,Time,1125,872,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,180,179,168,0,1,0,0,0,64,0,-1--1--1,,1|(1125,863)|
+1,181,136,170,0,1,0,0,0,64,0,-1--1--1,,1|(1426,814)|
+10,182,INITIAL TIME,1496,920,55,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,183,182,170,0,1,0,0,0,64,0,-1--1--1,,1|(1496,911)|
+10,184,Time,1496,920,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,185,184,170,0,1,0,0,0,64,0,-1--1--1,,1|(1496,911)|
+1,186,136,169,0,1,0,0,0,64,0,-1--1--1,,1|(1362,811)|
+10,187,FINAL TIME,1329,950,49,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,188,187,169,0,1,0,0,0,64,0,-1--1--1,,1|(1339,924)|
+10,189,Time,1356,917,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,190,189,169,0,1,0,0,0,64,0,-1--1--1,,1|(1356,908)|
+10,191,Experiment wk,211,-106,58,11,8,3,1,0,0,0,0,0
+1,192,191,1,0,1,0,0,0,128,0,-1--1--1,,1|(276,-36)|
+10,193,Time,273,29,28,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,194,193,1,0,1,0,0,0,64,0,-1--1--1,,1|(302,36)|
+1,195,191,2,0,1,0,0,0,64,0,-1--1--1,,1|(320,-63)|
+1,196,191,43,0,1,0,0,0,64,0,-1--1--1,,1|(218,177)|
+1,197,191,53,0,1,0,0,0,128,0,-1--1--1,,1|(504,194)|
+1,198,191,54,0,1,0,0,0,128,0,-1--1--1,,1|(748,189)|
+10,199,Supply Available for New Pts who can start 2nd visit,425,-108,87,20,8,3,0,0,0,0,0,0
+1,200,81,199,0,0,0,0,0,64,0,-1--1--1,,1|(520,-82)|
+1,201,1,199,0,0,0,0,0,64,0,-1--1--1,,1|(390,-21)|
+1,202,191,199,0,1,0,0,0,64,0,-1--1--1,,1|(296,-106)|
+1,203,83,199,0,0,0,0,0,64,0,-1--1--1,,1|(473,-23)|
+10,204,Appointments in Psychotherapy,699,-179,55,20,8,3,0,0,0,0,0,0
+10,205,Booking Rate,575,-178,45,11,8,3,0,0,0,0,0,0
+10,206,Completing Rate,823,-169,55,11,8,3,0,0,0,0,0,0
+1,207,1,205,0,0,0,0,0,128,0,-1--1--1,,1|(466,-62)|
+1,208,81,205,0,0,0,0,0,128,0,-1--1--1,,1|(589,-117)|
+10,209,Total Pts in Psych,652,-118,43,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,210,Pts per appt,1062,-210,51,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,211,209,204,0,0,0,0,0,128,0,-1--1--1,,1|(670,-142)|
+1,212,210,204,1,0,0,0,0,128,0,-1--1--1,,1|(883,-215)|
+1,213,191,94,0,1,0,0,0,64,0,-1--1--1,,1|(322,310)|
+1,214,191,116,0,1,0,0,0,64,0,-1--1--1,,1|(610,343)|
+1,215,191,136,0,1,0,0,0,64,0,-1--1--1,,1|(782,318)|
+10,216,Initiators who Complete,1255,83,46,20,8,3,1,0,0,0,0,0
+1,217,29,216,0,1,0,0,0,64,0,-1--1--1,,1|(1168,117)|
+10,218,Initiators who Quit Early,1262,-32,46,20,8,3,1,0,0,0,0,0
+1,219,28,218,0,1,0,0,0,64,0,-1--1--1,,1|(1169,14)|
+10,220,Completers who Graduate,1296,200,55,20,8,3,1,0,0,0,0,0
+1,221,9,220,0,1,0,0,0,64,0,-1--1--1,,1|(1245,232)|
+1,222,210,216,0,1,0,0,0,128,0,-1--1--1,,1|(1151,-73)|
+1,223,210,220,0,1,0,0,0,128,0,-1--1--1,,1|(1172,-15)|
+10,224,"From 1 Visit (1st Quartile)",637,431,55,20,8,3,1,0,0,0,0,0
+10,225,"From 1 Visit (Mean)",650,522,40,20,8,3,1,0,0,0,0,0
+10,226,"From 1 Visit (4th Quartile)",659,620,56,20,8,3,1,0,0,0,0,0
+10,227,"From 2 to 7 Visits (1st Quartile)",1123,367,58,20,8,3,1,0,0,0,0,0
+10,228,"From 2 to 7 Visits (Mean)",1124,469,58,20,8,3,1,0,0,0,0,0
+10,229,"From 2 to 7 Visits (4th Quartile)",1117,677,58,20,8,3,1,0,0,0,0,0
+10,230,"From 8 or More Visits (1st Quartile)",1658,395,70,20,8,3,1,0,0,0,0,0
+10,231,"From 8 or More Visits (Mean)",1645,495,52,20,8,3,1,0,0,0,0,0
+10,232,"From 8 or More Visits (4th Quartile)",1656,599,70,20,8,3,1,0,0,0,0,0
+1,233,17,224,0,1,0,0,0,128,0,-1--1--1,,1|(569,423)|
+1,234,20,225,0,1,0,0,0,128,0,-1--1--1,,1|(589,514)|
+1,235,23,226,0,1,0,0,0,128,0,-1--1--1,,1|(590,611)|
+1,236,18,227,0,1,0,0,0,128,0,-1--1--1,,1|(1033,394)|
+1,237,21,228,0,1,0,0,0,128,0,-1--1--1,,1|(1031,495)|
+1,238,24,229,0,1,0,0,0,128,0,-1--1--1,,1|(1028,641)|
+1,239,19,230,0,1,0,0,0,128,0,-1--1--1,,1|(1575,391)|
+1,240,22,231,0,1,0,0,0,128,0,-1--1--1,,1|(1571,491)|
+1,241,25,232,0,1,0,0,0,128,0,-1--1--1,,1|(1569,594)|
+1,242,210,224,0,1,0,0,0,128,0,-1--1--1,,1|(856,100)|
+1,243,210,225,0,1,0,0,0,128,0,-1--1--1,,1|(861,145)|
+1,244,210,226,0,1,0,0,0,128,0,-1--1--1,,1|(865,194)|
+1,245,210,227,0,1,0,0,0,128,0,-1--1--1,,1|(1090,67)|
+1,246,210,228,0,1,0,0,0,128,0,-1--1--1,,1|(1091,118)|
+1,247,210,229,0,1,0,0,0,128,0,-1--1--1,,1|(1088,222)|
+1,248,210,230,0,1,0,0,0,128,0,-1--1--1,,1|(1350,83)|
+1,249,210,231,0,1,0,0,0,128,0,-1--1--1,,1|(1345,132)|
+1,250,210,232,0,1,0,0,0,128,0,-1--1--1,,1|(1351,184)|
+1,251,210,218,0,1,0,0,0,128,0,-1--1--1,,1|(1151,-130)|
+1,252,83,206,0,0,0,0,0,128,0,-1--1--1,,1|(669,-60)|
 \\\---/// Sketch information - do not modify anything except names
 V300  Do not put anything below this section - it will be ignored
 *Psychotherapy Service
-$192-192-192,0,Meiryo|10||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,45,0
-10,1,Patients in First Visit,574,288,40,20,3,3,0,0,0,0,0,0
-12,2,48,411,279,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,3,48,744,287,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,4,6,3,4,0,0,22,0,0,0,-1--1--1,,1|(707,287)|
-1,5,6,1,100,0,0,22,0,0,0,-1--1--1,,1|(641,287)|
-11,6,48,674,287,6,8,34,3,0,0,1,0,0,0
-10,7,Ending 1,674,306,30,11,40,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,8,Median Time in Visit 1,745,445,51,20,8,3,0,0,0,0,0,0
-1,9,8,7,1,0,0,0,0,64,0,-1--1--1,,1|(725,365)|
-1,10,1,6,1,0,0,0,0,64,0,-1--1--1,,1|(628,259)|
-10,11,"<3mo Visit 2-7-n-More>3mo",1273,763,51,20,3,131,0,0,0,0,0,0
-12,12,48,1101,764,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,13,15,11,4,0,0,22,0,0,0,-1--1--1,,1|(1196,763)|
-1,14,15,12,100,0,0,22,0,0,0,-1--1--1,,1|(1135,763)|
-11,15,48,1165,763,6,8,34,3,0,0,1,0,0,0
-10,16,"Starting Psychotherapy- 2-7-n->3mo",1165,801,53,30,40,131,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,17,48,1432,762,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,18,20,17,4,0,0,22,0,0,0,-1--1--1,,1|(1398,766)|
-1,19,20,11,100,0,0,22,0,0,0,-1--1--1,,1|(1343,766)|
-11,20,48,1368,766,6,8,34,3,0,0,1,0,0,0
-10,21,"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7",1368,809,90,35,40,131,0,0,-1,0,0,0
-10,22,"Median Time in Visit 2-7-n-More>3mo",1461,723,67,20,8,3,0,0,0,0,0,0
-1,23,22,20,0,0,0,0,0,64,0,-1--1--1,,1|(1401,750)|
-1,24,11,20,1,0,0,0,0,64,0,-1--1--1,,1|(1316,734)|
-10,25,Patients in Over 7 Visits,1771,609,40,20,3,3,0,0,0,0,0,0
-12,26,48,1608,600,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,27,29,25,4,0,0,22,0,0,0,-1--1--1,,1|(1705,600)|
-1,28,29,26,100,0,0,22,0,0,0,-1--1--1,,1|(1643,600)|
-11,29,48,1674,600,6,8,34,3,0,0,1,0,0,0
-10,30,"Starting Psychotherapy- 8PL",1674,628,67,20,40,131,0,0,-1,0,0,0
-12,31,48,1941,608,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,32,34,31,4,0,0,22,0,0,0,-1--1--1,,1|(1904,608)|
-1,33,34,25,100,0,0,22,0,0,0,-1--1--1,,1|(1838,608)|
-11,34,48,1871,608,6,8,34,3,0,0,1,0,0,0
-10,35,Ending First 3months of Psychotherapy,1871,643,82,27,40,131,0,0,-1,0,0,0
-10,36,Median Time in Visit 8PL,1922,539,51,20,8,3,0,0,0,0,0,0
-1,37,36,34,0,0,0,0,0,64,0,-1--1--1,,1|(1895,575)|
-1,38,25,34,1,0,0,0,0,64,0,-1--1--1,,1|(1825,580)|
-10,39,"% Go on to 2-7 in <3mo",1009,475,59,20,8,3,0,0,0,0,0,0
-1,40,39,16,0,0,0,0,0,64,0,-1--1--1,,1|(1080,626)|
-10,41,"From1-LowD",582,1102,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,42,48,418,1099,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,43,45,41,4,0,0,22,0,0,0,-1--1--1,,1|(516,1101)|
-1,44,45,42,100,0,0,22,0,0,0,-1--1--1,,1|(453,1101)|
-11,45,48,484,1101,6,8,34,3,0,0,1,0,0,0
-10,46,"From1-PL3mo into Low D",484,1129,62,20,40,3,0,0,-1,0,0,0
-12,47,48,751,1107,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,48,50,47,4,0,0,22,0,0,0,-1--1--1,,1|(714,1108)|
-1,49,50,41,100,0,0,22,0,0,0,-1--1--1,,1|(648,1108)|
-11,50,48,681,1108,6,8,34,3,0,0,1,0,0,0
-10,51,"From1-+PLmo Ending Low D",681,1136,48,20,40,3,0,0,-1,0,0,0
-1,52,41,50,1,0,0,0,0,64,0,-1--1--1,,1|(638,1076)|
-10,53,"From1-MidD",582,1229,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,54,48,419,1218,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,55,57,53,4,0,0,22,0,0,0,-1--1--1,,1|(516,1220)|
-1,56,57,54,100,0,0,22,0,0,0,-1--1--1,,1|(454,1220)|
-11,57,48,485,1220,6,8,34,3,0,0,1,0,0,0
-10,58,"From1-PL3mo into Mid D",485,1248,62,20,40,3,0,0,-1,0,0,0
-12,59,48,752,1226,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,60,62,59,4,0,0,22,0,0,0,-1--1--1,,1|(715,1227)|
-1,61,62,53,100,0,0,22,0,0,0,-1--1--1,,1|(649,1227)|
-11,62,48,682,1227,6,8,34,3,0,0,1,0,0,0
-10,63,"From1-+PLmo Ending Mid D",682,1255,48,20,40,3,0,0,-1,0,0,0
-1,64,53,62,1,0,0,0,0,64,0,-1--1--1,,1|(636,1198)|
-10,65,"From1-HighD",592,1342,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,66,48,429,1331,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,67,69,65,4,0,0,22,0,0,0,-1--1--1,,1|(526,1333)|
-1,68,69,66,100,0,0,22,0,0,0,-1--1--1,,1|(464,1333)|
-11,69,48,495,1333,6,8,34,3,0,0,1,0,0,0
-10,70,"From1-PL3mo into High D",495,1361,62,20,40,3,0,0,-1,0,0,0
-12,71,48,762,1339,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,72,74,71,4,0,0,22,0,0,0,-1--1--1,,1|(725,1340)|
-1,73,74,65,100,0,0,22,0,0,0,-1--1--1,,1|(659,1340)|
-11,74,48,692,1340,6,8,34,3,0,0,1,0,0,0
-10,75,"From1-PL3mo Ending High D",692,1368,48,20,40,3,0,0,-1,0,0,0
-1,76,65,74,1,0,0,0,0,64,0,-1--1--1,,1|(646,1311)|
-10,77,"PL3mo % starting MidD",530,1191,59,20,8,3,0,0,0,0,0,0
-10,78,"PL3mo % starting HighD",545,1306,59,20,8,3,0,0,0,0,0,0
-1,79,78,69,0,0,0,0,0,64,0,-1--1--1,,1|(510,1324)|
-1,80,77,58,0,0,0,0,0,64,0,-1--1--1,,1|(512,1214)|
-10,81,"PL3mo % starting LowD",543,1061,59,20,8,3,0,0,0,0,0,0
-1,82,81,45,0,0,0,0,0,128,0,-1--1--1,,1|(506,1085)|
-10,83,"%Visit1<3mo and More",161,948,60,20,8,3,0,0,0,0,0,0
-10,84,"From2-7-LowD",1336,1108,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,85,48,1173,1099,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,86,88,84,4,0,0,22,0,0,0,-1--1--1,,1|(1270,1099)|
-1,87,88,85,100,0,0,22,0,0,0,-1--1--1,,1|(1208,1099)|
-11,88,48,1239,1099,6,8,34,3,0,0,1,0,0,0
-10,89,"From2-7-PL3mo into Low D",1239,1127,55,20,40,3,0,0,-1,0,0,0
-12,90,48,1506,1107,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,91,93,90,4,0,0,22,0,0,0,-1--1--1,,1|(1469,1106)|
-1,92,93,84,100,0,0,22,0,0,0,-1--1--1,,1|(1403,1106)|
-11,93,48,1436,1106,6,8,34,3,0,0,1,0,0,0
-10,94,"From2-7-PL3mo Ending Low D",1436,1134,55,20,40,3,0,0,-1,0,0,0
-10,95,"From2-7-PL3mo Median Time in Lower Q",1498,1064,81,20,8,3,0,0,0,0,0,0
-1,96,95,93,0,0,0,0,0,64,0,-1--1--1,,1|(1460,1089)|
-1,97,84,93,1,0,0,0,0,64,0,-1--1--1,,1|(1390,1079)|
-10,98,"From2-7-MidD",1337,1227,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,99,48,1174,1223,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,100,102,98,4,0,0,22,0,0,0,-1--1--1,,1|(1271,1220)|
-1,101,102,99,100,0,0,22,0,0,0,-1--1--1,,1|(1209,1220)|
-11,102,48,1240,1220,6,8,34,3,0,0,1,0,0,0
-10,103,"From2-7-PL3mo into Mid D",1240,1248,55,20,40,3,0,0,-1,0,0,0
-12,104,48,1507,1226,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,105,107,104,4,0,0,22,0,0,0,-1--1--1,,1|(1470,1225)|
-1,106,107,98,100,0,0,22,0,0,0,-1--1--1,,1|(1404,1225)|
-11,107,48,1437,1225,6,8,34,3,0,0,1,0,0,0
-10,108,"From2-7-PL3mo Ending Mid D",1437,1253,55,20,40,3,0,0,-1,0,0,0
-10,109,"From2-7-PL3mo Median Time in Mid Qs",1502,1188,75,20,8,3,0,0,0,0,0,0
-1,110,109,107,0,0,0,0,0,64,0,-1--1--1,,1|(1460,1211)|
-1,111,98,107,1,0,0,0,0,64,0,-1--1--1,,1|(1391,1198)|
-10,112,"From2-7-HighD",1347,1340,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,113,48,1184,1339,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,114,116,112,4,0,0,22,0,0,0,-1--1--1,,1|(1281,1336)|
-1,115,116,113,100,0,0,22,0,0,0,-1--1--1,,1|(1219,1336)|
-11,116,48,1250,1336,6,8,34,3,0,0,1,0,0,0
-10,117,"From2-7-PL3mo into High D",1250,1364,55,20,40,3,0,0,-1,0,0,0
-12,118,48,1517,1343,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,119,121,118,4,0,0,22,0,0,0,-1--1--1,,1|(1480,1338)|
-1,120,121,112,100,0,0,22,0,0,0,-1--1--1,,1|(1414,1338)|
-11,121,48,1447,1338,6,8,34,3,0,0,1,0,0,0
-10,122,"From2-7-PL3mo Ending High D",1447,1366,55,20,40,3,0,0,-1,0,0,0
-10,123,"From2-7-PL3mo Median Time in Upper Q",1517,1296,80,20,8,3,0,0,0,0,0,0
-1,124,123,121,0,0,0,0,0,64,0,-1--1--1,,1|(1474,1321)|
-1,125,112,121,1,0,0,0,0,64,0,-1--1--1,,1|(1401,1311)|
-10,126,"%Visit2-7-n-Done",955,733,63,17,8,131,0,0,0,0,0,0
-1,127,21,88,1,0,0,0,0,64,0,-1--1--1,,1|(1181,982)|
-1,128,21,102,1,0,0,0,0,64,0,-1--1--1,,1|(1139,1006)|
-1,129,21,116,1,0,0,0,0,64,0,-1--1--1,,1|(1096,1028)|
-10,130,"PL3mo % starting LowD",1342,1046,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,131,"PL3mo % starting MidD",1280,1186,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,132,"PL3mo % starting HighD",1296,1290,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,133,130,88,0,0,0,0,0,128,0,-1--1--1,,1|(1280,1077)|
-1,134,131,102,0,0,0,0,0,128,0,-1--1--1,,1|(1256,1206)|
-1,135,132,117,0,0,0,0,0,128,0,-1--1--1,,1|(1276,1321)|
-10,136,"From8PL-LowD",2142,1088,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,137,48,1979,1079,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,138,140,136,4,0,0,22,0,0,0,-1--1--1,,1|(2076,1081)|
-1,139,140,137,100,0,0,22,0,0,0,-1--1--1,,1|(2014,1081)|
-11,140,48,2045,1081,6,8,34,3,0,0,1,0,0,0
-10,141,"From8PL-PL3mo into Low D",2045,1109,55,20,40,3,0,0,-1,0,0,0
-12,142,48,2312,1087,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,143,145,142,4,0,0,22,0,0,0,-1--1--1,,1|(2275,1089)|
-1,144,145,136,100,0,0,22,0,0,0,-1--1--1,,1|(2209,1089)|
-11,145,48,2242,1089,6,8,34,3,0,0,1,0,0,0
-10,146,"From8PL-PL3mo Ending Low D",2242,1117,55,20,40,3,0,0,-1,0,0,0
-10,147,"From8PL-PL3mo Median Time in Lower Q",2304,1037,81,20,8,3,0,0,0,0,0,0
-1,148,147,145,0,0,0,0,0,64,0,-1--1--1,,1|(2268,1066)|
-1,149,136,145,1,0,0,0,0,64,0,-1--1--1,,1|(2196,1059)|
-10,150,"From8PL-MidD",2143,1207,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,151,48,1980,1198,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,152,154,150,4,0,0,22,0,0,0,-1--1--1,,1|(2077,1200)|
-1,153,154,151,100,0,0,22,0,0,0,-1--1--1,,1|(2015,1200)|
-11,154,48,2046,1200,6,8,34,3,0,0,1,0,0,0
-10,155,"From8PL-PL3mo into Mid D",2046,1228,55,20,40,3,0,0,-1,0,0,0
-12,156,48,2313,1206,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,157,159,156,4,0,0,22,0,0,0,-1--1--1,,1|(2276,1208)|
-1,158,159,150,100,0,0,22,0,0,0,-1--1--1,,1|(2210,1208)|
-11,159,48,2243,1208,6,8,34,3,0,0,1,0,0,0
-10,160,"From8PL-PL3mo Ending Mid D",2243,1236,55,20,40,3,0,0,-1,0,0,0
-10,161,"From8PL-PL3mo MedianTime in Mid Qs",2308,1161,73,20,8,3,0,0,0,0,0,0
-1,162,161,159,0,0,0,0,0,64,0,-1--1--1,,1|(2269,1188)|
-1,163,150,159,1,0,0,0,0,64,0,-1--1--1,,1|(2197,1178)|
-10,164,"From8PL-HighD",2153,1320,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,165,48,1990,1317,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,166,168,164,4,0,0,22,0,0,0,-1--1--1,,1|(2087,1317)|
-1,167,168,165,100,0,0,22,0,0,0,-1--1--1,,1|(2025,1317)|
-11,168,48,2056,1317,6,8,34,3,0,0,1,0,0,0
-10,169,"From8PL-PL3mo into High D",2056,1345,55,20,40,3,0,0,-1,0,0,0
-12,170,48,2323,1319,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,171,173,170,4,0,0,22,0,0,0,-1--1--1,,1|(2286,1321)|
-1,172,173,164,100,0,0,22,0,0,0,-1--1--1,,1|(2220,1321)|
-11,173,48,2253,1321,6,8,34,3,0,0,1,0,0,0
-10,174,"From8PL-PL3mo Ending High D",2253,1349,55,20,40,3,0,0,-1,0,0,0
-10,175,"From8PL-PL3mo Median Time in Upper Q",2323,1272,80,20,8,3,0,0,0,0,0,0
-1,176,175,173,0,0,0,0,0,64,0,-1--1--1,,1|(2281,1300)|
-1,177,164,173,1,0,0,0,0,64,0,-1--1--1,,1|(2207,1291)|
-10,178,"%Visit8PL-n-Done",2069,763,40,21,8,3,0,0,0,0,0,0
-10,179,"PL3mo % starting LowD",2091,1039,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,180,"PL3mo % starting MidD",2091,1167,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,181,"PL3mo % starting HighD",2100,1281,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,182,179,140,0,0,0,0,0,128,0,-1--1--1,,1|(2064,1063)|
-1,183,180,154,0,0,0,0,0,128,0,-1--1--1,,1|(2062,1187)|
-1,184,181,169,0,0,0,0,0,128,0,-1--1--1,,1|(2082,1307)|
-10,185,New Patient Scheduling Efficiency,599,447,70,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||64-160-98
-10,186,Pts per Appt,485,437,41,11,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,187,Starting Psychotherapy,469,361,49,20,8,131,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,188,Appointments Available for New Patients,145,359,60,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,189,185,187,0,0,0,0,0,128,0,-1--1--1,,1|(539,407)|
-1,190,186,187,0,0,0,0,0,128,0,-1--1--1,,1|(479,410)|
-10,191,EightPlusAfter,2224,1406,46,11,8,3,2,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,192,164,191,0,2,0,0,0,128,0,-1--1--1,,1|(2187,1362)|
-1,193,150,191,0,2,0,0,0,128,0,-1--1--1,,1|(2182,1304)|
-1,194,136,191,0,2,0,0,0,128,0,-1--1--1,,1|(2182,1244)|
-10,195,TwoSevenAfter,1376,1458,51,11,8,3,2,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,196,112,195,0,2,0,0,0,128,0,-1--1--1,,1|(1360,1396)|
-1,197,98,195,0,2,0,0,0,128,0,-1--1--1,,1|(1355,1340)|
-1,198,84,195,0,2,0,0,0,128,0,-1--1--1,,1|(1355,1280)|
-10,199,OneAfter,756,1446,31,11,8,3,2,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,200,65,199,0,2,0,0,0,128,0,-1--1--1,,1|(674,1394)|
-1,201,53,199,0,2,0,0,0,128,0,-1--1--1,,1|(668,1336)|
-1,202,41,199,0,2,0,0,0,128,0,-1--1--1,,1|(667,1272)|
-10,203,"<3mo Visit 2-7 -n-done",1303,433,40,20,3,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,204,48,1140,433,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,205,207,203,4,0,0,22,0,0,0,-1--1--1,,1|(1233,431)|
-1,206,207,204,100,0,0,22,0,0,0,-1--1--1,,1|(1170,431)|
-11,207,48,1197,431,6,8,34,3,0,0,1,0,0,0
-10,208,"Starting Psychotherapy 2-7-n-Done",1197,459,78,20,40,131,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,209,48,1536,434,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,210,212,209,4,0,0,22,0,0,0,-1--1--1,,1|(1483,434)|
-1,211,212,203,100,0,0,22,0,0,0,-1--1--1,,1|(1385,434)|
-11,212,48,1434,434,6,8,34,3,0,0,1,0,0,0
-10,213,Ending During Visit 2 to 7 Rate,1434,462,69,20,40,3,0,0,-1,0,0,0
-1,214,126,208,1,0,0,0,0,128,0,-1--1--1,,1|(1098,532)|
-1,215,203,212,1,0,0,0,0,128,0,-1--1--1,,1|(1384,402)|
-10,216,"Median Time in Visit 2-7-n-Done",1499,369,67,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,217,216,212,0,0,0,0,0,128,0,-1--1--1,,1|(1463,404)|
-10,218,"<3mo Visit 2-7-n-More<3mo",1308,599,53,19,3,131,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,219,220,218,4,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1221,603)|
-11,220,444,1181,603,6,8,34,3,0,0,1,0,0,0
-10,221,"Starting Psychotherapy 2-7-n-More<3mo",1181,631,78,20,40,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,222,48,1528,601,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,223,225,222,4,0,0,22,0,0,0,-1--1--1,,1|(1485,601)|
-1,224,225,218,100,0,0,22,0,0,0,-1--1--1,,1|(1400,601)|
-11,225,48,1446,601,6,8,34,3,0,0,1,0,0,0
-10,226,Completion Rate,1446,629,55,11,40,3,0,0,-1,0,0,0
-1,227,218,225,1,0,0,0,0,128,0,-1--1--1,,1|(1407,567)|
-10,228,"Median Time in Visit 2-7-More<3mo",1491,536,67,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,229,228,225,0,0,0,0,0,128,0,-1--1--1,,1|(1467,570)|
-1,230,39,221,0,0,0,0,0,128,0,-1--1--1,,1|(1089,548)|
-1,231,39,208,0,0,0,0,0,128,0,-1--1--1,,1|(1086,468)|
-1,232,226,30,1,0,0,0,0,128,0,-1--1--1,,1|(1547,628)|
-10,233,"%Visit2-7-n-More<3mo",1326,677,40,21,8,3,0,0,0,0,0,0
-1,234,233,221,0,0,0,0,0,128,0,-1--1--1,,1|(1271,660)|
-1,235,233,15,0,0,0,0,0,128,0,-1--1--1,,1|(1234,725)|
-1,236,126,16,0,0,0,0,0,128,0,-1--1--1,,1|(1052,764)|
-10,237,Patients in Care More Than 3 Months,1281,1550,72,20,8,3,2,0,0,0,0,0
-1,238,199,237,0,2,0,0,0,128,0,-1--1--1,,1|(991,1492)|
-1,239,195,237,0,2,0,0,0,128,0,-1--1--1,,1|(1338,1494)|
-1,240,191,237,0,2,0,0,0,128,0,-1--1--1,,1|(1772,1474)|
-1,241,8,36,1,0,0,0,0,128,0,-1--1--1,,1|(1496,229)|
-1,242,228,36,1,0,0,0,0,128,0,-1--1--1,,1|(1688,480)|
-12,243,0,971,1465,113,113,6,135,0,0,-1,0,0,0
+$192-192-192,0,Meiryo|10||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,85,0
+10,1,Patients in First Visit,-426,28,40,20,3,3,0,0,0,0,0,0
+12,2,48,-589,19,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+12,3,48,-256,27,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,4,6,3,4,0,0,22,0,0,0,-1--1--1,,1|(-293,27)|
+1,5,6,1,100,0,0,22,0,0,0,-1--1--1,,1|(-359,27)|
+11,6,48,-326,27,6,8,34,3,0,0,1,0,0,0
+10,7,Ending First Visit,-326,46,54,11,40,3,0,0,-1,0,0,0
+10,8,Median Time in Visit 1,-255,185,51,20,8,3,0,0,0,0,0,0
+1,9,8,7,1,0,0,0,0,64,0,-1--1--1,,1|(-275,105)|
+1,10,1,6,1,0,0,0,0,64,0,-1--1--1,,1|(-372,-1)|
+10,11,Initiators who will Return,273,503,51,20,3,131,0,0,0,0,0,0
+12,12,48,101,504,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,13,15,11,4,0,0,22,0,0,0,-1--1--1,,1|(196,503)|
+1,14,15,12,100,0,0,22,0,0,0,-1--1--1,,1|(135,503)|
+11,15,48,165,503,6,8,34,3,0,0,1,0,0,0
+10,16,Initation Rate who will Return,165,541,62,20,40,131,0,0,-1,0,0,0
+12,17,48,432,502,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,18,20,17,4,0,0,22,0,0,0,-1--1--1,,1|(398,506)|
+1,19,20,11,100,0,0,22,0,0,0,-1--1--1,,1|(343,506)|
+11,20,48,368,506,6,8,34,3,0,0,1,0,0,0
+10,21,"Continuing Treatment Rate (After 3 Months) from Visit 2 to 7",368,549,90,35,40,131,0,0,-1,0,0,0
+10,22,Initiators Who Return Duration,461,463,54,20,8,3,0,0,0,0,0,0
+1,23,22,20,0,0,0,0,0,64,0,-1--1--1,,1|(401,490)|
+1,24,11,20,1,0,0,0,0,64,0,-1--1--1,,1|(316,474)|
+10,25,Patients in Over 7 Visits,771,349,40,20,3,3,0,0,0,0,0,0
+12,26,48,608,340,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,27,29,25,4,0,0,22,0,0,0,-1--1--1,,1|(705,340)|
+1,28,29,26,100,0,0,22,0,0,0,-1--1--1,,1|(643,340)|
+11,29,48,674,340,6,8,34,3,0,0,1,0,0,0
+10,30,Starting Visit 8,674,368,48,11,40,131,0,0,-1,0,0,0
+12,31,48,941,348,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,32,34,31,4,0,0,22,0,0,0,-1--1--1,,1|(904,348)|
+1,33,34,25,100,0,0,22,0,0,0,-1--1--1,,1|(838,348)|
+11,34,48,871,348,6,8,34,3,0,0,1,0,0,0
+10,35,Ending After 8 or More Visits Rate,871,383,57,20,40,131,0,0,-1,0,0,0
+10,36,Completers Duration,922,279,39,20,8,3,0,0,0,0,0,0
+1,37,36,34,0,0,0,0,0,64,0,-1--1--1,,1|(895,315)|
+1,38,25,34,1,0,0,0,0,64,0,-1--1--1,,1|(825,320)|
+10,39,"Actual Starters Who Initiate %",9,215,67,20,8,3,0,0,0,0,0,0
+1,40,39,16,0,0,0,0,0,64,0,-1--1--1,,1|(83,371)|
+10,41,"From Starters-LowD",-418,842,40,20,3,3,0,0,0,0,0,0
+12,42,48,-582,839,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,43,45,41,4,0,0,22,0,0,0,-1--1--1,,1|(-484,841)|
+1,44,45,42,100,0,0,22,0,0,0,-1--1--1,,1|(-547,841)|
+11,45,48,-516,841,6,8,34,3,0,0,1,0,0,0
+10,46,From Starters into Low D,-516,869,60,20,40,3,0,0,-1,0,0,0
+12,47,48,-249,847,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,48,50,47,4,0,0,22,0,0,0,-1--1--1,,1|(-286,848)|
+1,49,50,41,100,0,0,22,0,0,0,-1--1--1,,1|(-351,848)|
+11,50,48,-319,848,6,8,34,3,0,0,1,0,0,0
+10,51,From Starters Ending Low D,-319,876,46,20,40,3,0,0,-1,0,0,0
+1,52,41,50,1,0,0,0,0,64,0,-1--1--1,,1|(-362,816)|
+10,53,"From Starters-MidD",-418,969,40,20,3,3,0,0,0,0,0,0
+12,54,48,-581,958,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,55,57,53,4,0,0,22,0,0,0,-1--1--1,,1|(-483,960)|
+1,56,57,54,100,0,0,22,0,0,0,-1--1--1,,1|(-546,960)|
+11,57,48,-515,960,6,8,34,3,0,0,1,0,0,0
+10,58,From Starters into Mid D,-515,988,60,20,40,3,0,0,-1,0,0,0
+12,59,48,-248,966,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,60,62,59,4,0,0,22,0,0,0,-1--1--1,,1|(-285,967)|
+1,61,62,53,100,0,0,22,0,0,0,-1--1--1,,1|(-351,967)|
+11,62,48,-318,967,6,8,34,3,0,0,1,0,0,0
+10,63,From Starters Ending Mid D,-318,995,46,20,40,3,0,0,-1,0,0,0
+1,64,53,62,1,0,0,0,0,64,0,-1--1--1,,1|(-364,938)|
+10,65,"From Starters-HighD",-408,1082,40,20,3,3,0,0,0,0,0,0
+12,66,48,-571,1071,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,67,69,65,4,0,0,22,0,0,0,-1--1--1,,1|(-473,1073)|
+1,68,69,66,100,0,0,22,0,0,0,-1--1--1,,1|(-536,1073)|
+11,69,48,-505,1073,6,8,34,3,0,0,1,0,0,0
+10,70,From Starters into High D,-505,1101,60,20,40,3,0,0,-1,0,0,0
+12,71,48,-238,1079,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,72,74,71,4,0,0,22,0,0,0,-1--1--1,,1|(-275,1080)|
+1,73,74,65,100,0,0,22,0,0,0,-1--1--1,,1|(-341,1080)|
+11,74,48,-308,1080,6,8,34,3,0,0,1,0,0,0
+10,75,From Starters Ending High D,-308,1108,48,20,40,3,0,0,-1,0,0,0
+1,76,65,74,1,0,0,0,0,64,0,-1--1--1,,1|(-354,1051)|
+10,77,"Starting MidD %",-470,931,54,11,8,3,0,0,0,0,0,0
+10,78,"Starting HighD %",-455,1046,57,11,8,3,0,0,0,0,0,0
+1,79,78,69,0,0,0,0,0,64,0,-1--1--1,,1|(-480,1060)|
+1,80,77,58,0,0,0,0,0,64,0,-1--1--1,,1|(-484,949)|
+10,81,"Starting LowD %",-457,801,56,11,8,3,0,0,0,0,0,0
+1,82,81,45,0,0,0,0,0,128,0,-1--1--1,,1|(-486,820)|
+10,83,"Actual Starters Who Return Later %",-839,688,67,20,8,3,0,0,0,0,0,0
+10,84,"From Initiators-LowD",336,848,40,20,3,3,0,0,0,0,0,0
+12,85,48,173,839,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,86,88,84,4,0,0,22,0,0,0,-1--1--1,,1|(270,839)|
+1,87,88,85,100,0,0,22,0,0,0,-1--1--1,,1|(208,839)|
+11,88,48,239,839,6,8,34,3,0,0,1,0,0,0
+10,89,From Initiators into Low D,239,867,64,20,40,3,0,0,-1,0,0,0
+12,90,48,506,847,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,91,93,90,4,0,0,22,0,0,0,-1--1--1,,1|(469,846)|
+1,92,93,84,100,0,0,22,0,0,0,-1--1--1,,1|(403,846)|
+11,93,48,436,846,6,8,34,3,0,0,1,0,0,0
+10,94,From Initiators Ending Low D,436,874,49,20,40,3,0,0,-1,0,0,0
+10,95,From Initiators Median Time in Lower Q,498,804,75,20,8,3,0,0,0,0,0,0
+1,96,95,93,0,0,0,0,0,64,0,-1--1--1,,1|(460,829)|
+1,97,84,93,1,0,0,0,0,64,0,-1--1--1,,1|(390,819)|
+10,98,"From Initiators-MidD",337,967,40,20,3,3,0,0,0,0,0,0
+12,99,48,174,963,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,100,102,98,4,0,0,22,0,0,0,-1--1--1,,1|(271,960)|
+1,101,102,99,100,0,0,22,0,0,0,-1--1--1,,1|(209,960)|
+11,102,48,240,960,6,8,34,3,0,0,1,0,0,0
+10,103,From Initiators into Mid D,240,988,49,20,40,3,0,0,-1,0,0,0
+12,104,48,507,966,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,105,107,104,4,0,0,22,0,0,0,-1--1--1,,1|(470,965)|
+1,106,107,98,100,0,0,22,0,0,0,-1--1--1,,1|(404,965)|
+11,107,48,437,965,6,8,34,3,0,0,1,0,0,0
+10,108,From Initiators Ending Mid D,437,993,49,20,40,3,0,0,-1,0,0,0
+10,109,From Initiators Median Time in Mid Qs,502,928,75,20,8,3,0,0,0,0,0,0
+1,110,109,107,0,0,0,0,0,64,0,-1--1--1,,1|(460,951)|
+1,111,98,107,1,0,0,0,0,64,0,-1--1--1,,1|(391,938)|
+10,112,"From Initiators-HighD",347,1080,40,20,3,3,0,0,0,0,0,0
+12,113,48,184,1079,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,114,116,112,4,0,0,22,0,0,0,-1--1--1,,1|(281,1076)|
+1,115,116,113,100,0,0,22,0,0,0,-1--1--1,,1|(219,1076)|
+11,116,48,250,1076,6,8,34,3,0,0,1,0,0,0
+10,117,From Initiators into High D,250,1104,64,20,40,3,0,0,-1,0,0,0
+12,118,48,517,1083,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,119,121,118,4,0,0,22,0,0,0,-1--1--1,,1|(480,1078)|
+1,120,121,112,100,0,0,22,0,0,0,-1--1--1,,1|(414,1078)|
+11,121,48,447,1078,6,8,34,3,0,0,1,0,0,0
+10,122,From Initiators Ending High D,447,1106,49,20,40,3,0,0,-1,0,0,0
+10,123,From Initiators Median Time in Upper Q,517,1036,75,20,8,3,0,0,0,0,0,0
+1,124,123,121,0,0,0,0,0,64,0,-1--1--1,,1|(474,1061)|
+1,125,112,121,1,0,0,0,0,64,0,-1--1--1,,1|(401,1051)|
+10,126,"Actual Initiators Who Quit Early %",-45,473,70,20,8,131,0,0,0,0,0,0
+1,127,21,88,1,0,0,0,0,64,0,-1--1--1,,1|(181,722)|
+1,128,21,102,1,0,0,0,0,64,0,-1--1--1,,1|(139,746)|
+1,129,21,116,1,0,0,0,0,64,0,-1--1--1,,1|(96,768)|
+10,130,"Starting LowD %",342,786,53,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+10,131,"Starting MidD %",280,926,51,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+10,132,"Starting HighD %",296,1030,55,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,133,130,88,0,0,0,0,0,128,0,-1--1--1,,1|(280,817)|
+1,134,131,102,0,0,0,0,0,128,0,-1--1--1,,1|(256,946)|
+1,135,132,117,0,0,0,0,0,128,0,-1--1--1,,1|(276,1061)|
+10,136,"From Completers-LowD",1142,828,40,20,3,3,0,0,0,0,0,0
+12,137,48,979,819,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,138,140,136,4,0,0,22,0,0,0,-1--1--1,,1|(1076,821)|
+1,139,140,137,100,0,0,22,0,0,0,-1--1--1,,1|(1014,821)|
+11,140,48,1045,821,6,8,34,3,0,0,1,0,0,0
+10,141,From Completers into Low D,1045,849,57,20,40,3,0,0,-1,0,0,0
+12,142,48,1312,827,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,143,145,142,4,0,0,22,0,0,0,-1--1--1,,1|(1275,829)|
+1,144,145,136,100,0,0,22,0,0,0,-1--1--1,,1|(1209,829)|
+11,145,48,1242,829,6,8,34,3,0,0,1,0,0,0
+10,146,From Completers Ending Low D,1242,857,57,20,40,3,0,0,-1,0,0,0
+10,147,From Completers Median Time in Lower Q,1304,777,81,20,8,3,0,0,0,0,0,0
+1,148,147,145,0,0,0,0,0,64,0,-1--1--1,,1|(1268,806)|
+1,149,136,145,1,0,0,0,0,64,0,-1--1--1,,1|(1196,799)|
+10,150,"From Completers-MidD",1143,947,40,20,3,3,0,0,0,0,0,0
+12,151,48,980,938,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,152,154,150,4,0,0,22,0,0,0,-1--1--1,,1|(1077,940)|
+1,153,154,151,100,0,0,22,0,0,0,-1--1--1,,1|(1015,940)|
+11,154,48,1046,940,6,8,34,3,0,0,1,0,0,0
+10,155,From Completers into Mid D,1046,968,57,20,40,3,0,0,-1,0,0,0
+12,156,48,1313,946,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,157,159,156,4,0,0,22,0,0,0,-1--1--1,,1|(1276,948)|
+1,158,159,150,100,0,0,22,0,0,0,-1--1--1,,1|(1210,948)|
+11,159,48,1243,948,6,8,34,3,0,0,1,0,0,0
+10,160,From Completers Ending Mid D,1243,976,57,20,40,3,0,0,-1,0,0,0
+10,161,From Completers MedianTime in Mid Qs,1308,901,73,20,8,3,0,0,0,0,0,0
+1,162,161,159,0,0,0,0,0,64,0,-1--1--1,,1|(1269,928)|
+1,163,150,159,1,0,0,0,0,64,0,-1--1--1,,1|(1197,918)|
+10,164,"From Completers-HighD",1153,1060,40,20,3,3,0,0,0,0,0,0
+12,165,48,990,1057,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,166,168,164,4,0,0,22,0,0,0,-1--1--1,,1|(1087,1057)|
+1,167,168,165,100,0,0,22,0,0,0,-1--1--1,,1|(1025,1057)|
+11,168,48,1056,1057,6,8,34,3,0,0,1,0,0,0
+10,169,From Completers into High D,1056,1085,57,20,40,3,0,0,-1,0,0,0
+12,170,48,1323,1059,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,171,173,170,4,0,0,22,0,0,0,-1--1--1,,1|(1286,1061)|
+1,172,173,164,100,0,0,22,0,0,0,-1--1--1,,1|(1220,1061)|
+11,173,48,1253,1061,6,8,34,3,0,0,1,0,0,0
+10,174,From Completers Ending High D,1253,1089,57,20,40,3,0,0,-1,0,0,0
+10,175,From Completers Median Time in Upper Q,1323,1012,80,20,8,3,0,0,0,0,0,0
+1,176,175,173,0,0,0,0,0,64,0,-1--1--1,,1|(1281,1040)|
+1,177,164,173,1,0,0,0,0,64,0,-1--1--1,,1|(1207,1031)|
+10,178,"Actual Completers Who Graduate %",1069,503,61,20,8,3,0,0,0,0,0,0
+10,179,"Starting LowD %",1091,779,53,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,180,"Starting MidD %",1091,907,51,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,181,"Starting HighD %",1100,1021,55,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,182,179,140,0,0,0,0,0,128,0,-1--1--1,,1|(1064,803)|
+1,183,180,154,0,0,0,0,0,128,0,-1--1--1,,1|(1062,927)|
+1,184,181,168,0,0,0,0,0,128,0,-1--1--1,,1|(1073,1042)|
+10,185,New Patient Scheduling Efficiency,-401,187,70,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||64-160-98
+10,186,Pts per appt,-515,177,41,11,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,187,Starting Psychotherapy,-531,101,49,20,8,131,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,188,Appointments Available for New Patients,-855,99,60,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,189,185,187,0,0,0,0,0,128,0,-1--1--1,,1|(-459,148)|
+1,190,186,187,0,0,0,0,0,128,0,-1--1--1,,1|(-520,151)|
+10,191,EightPlusAfter,1224,1146,46,11,8,3,2,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,192,164,191,0,2,0,0,0,128,0,-1--1--1,,1|(1187,1102)|
+1,193,150,191,0,2,0,0,0,128,0,-1--1--1,,1|(1182,1044)|
+1,194,136,191,0,2,0,0,0,128,0,-1--1--1,,1|(1182,984)|
+10,195,TwoSevenAfter,376,1198,51,11,8,3,2,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,196,112,195,0,2,0,0,0,128,0,-1--1--1,,1|(360,1136)|
+1,197,98,195,0,2,0,0,0,128,0,-1--1--1,,1|(355,1080)|
+1,198,84,195,0,2,0,0,0,128,0,-1--1--1,,1|(355,1020)|
+10,199,OneAfter,-244,1186,31,11,8,3,2,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,200,65,199,0,2,0,0,0,128,0,-1--1--1,,1|(-325,1134)|
+1,201,53,199,0,2,0,0,0,128,0,-1--1--1,,1|(-331,1076)|
+1,202,41,199,0,2,0,0,0,128,0,-1--1--1,,1|(-332,1012)|
+10,203,Initiators who will Quit,303,173,40,20,3,3,0,0,0,0,0,0
+12,204,48,140,173,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,205,207,203,4,0,0,22,0,0,0,-1--1--1,,1|(233,171)|
+1,206,207,204,100,0,0,22,0,0,0,-1--1--1,,1|(170,171)|
+11,207,48,197,171,6,8,34,3,0,0,1,0,0,0
+10,208,Initiation Rate who will Quit,197,199,64,20,40,131,0,0,-1,0,0,0
+12,209,48,536,174,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,210,212,209,4,0,0,22,0,0,0,-1--1--1,,1|(483,174)|
+1,211,212,203,100,0,0,22,0,0,0,-1--1--1,,1|(385,174)|
+11,212,48,434,174,6,8,34,3,0,0,1,0,0,0
+10,213,Ending During Visit 2 to 7 Rate,434,202,69,20,40,3,0,0,-1,0,0,0
+1,214,126,208,1,0,0,0,0,128,0,-1--1--1,,1|(98,272)|
+1,215,203,212,1,0,0,0,0,128,0,-1--1--1,,1|(384,142)|
+10,216,Initiators Who Quit Early Duration,499,109,63,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,217,216,212,0,0,0,0,0,128,0,-1--1--1,,1|(463,145)|
+10,218,Initiators who will Continue,308,339,53,19,3,131,0,0,0,0,0,0
+1,219,220,218,4,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(221,343)|
+11,220,620,181,343,6,8,34,3,0,0,1,0,0,0
+10,221,Initiation Rate who will Complete,181,371,64,20,40,3,0,0,-1,0,0,0
+12,222,48,528,341,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,223,225,222,4,0,0,22,0,0,0,-1--1--1,,1|(485,341)|
+1,224,225,218,100,0,0,22,0,0,0,-1--1--1,,1|(400,341)|
+11,225,48,446,341,6,8,34,3,0,0,1,0,0,0
+10,226,Continuting on to Visit 8 Rate,446,369,58,20,40,3,0,0,-1,0,0,0
+1,227,218,225,1,0,0,0,0,128,0,-1--1--1,,1|(407,307)|
+10,228,Initiators Who Graduate Duration,491,276,62,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,229,228,225,0,0,0,0,0,128,0,-1--1--1,,1|(467,310)|
+1,230,39,221,0,0,0,0,0,128,0,-1--1--1,,1|(89,288)|
+1,231,39,208,0,0,0,0,0,128,0,-1--1--1,,1|(97,207)|
+1,232,226,30,1,0,0,0,0,128,0,-1--1--1,,1|(558,368)|
+10,233,"Actual Initiators Who Complete %",326,417,70,20,8,3,0,0,0,0,0,0
+1,234,233,221,0,0,0,0,0,128,0,-1--1--1,,1|(260,396)|
+1,235,233,15,0,0,0,0,0,128,0,-1--1--1,,1|(235,465)|
+1,236,126,16,0,0,0,0,0,128,0,-1--1--1,,1|(52,504)|
+10,237,Patients in Care More Than 3 Months,281,1290,72,20,8,3,2,0,0,0,0,0
+1,238,199,237,0,2,0,0,0,128,0,-1--1--1,,1|(-9,1232)|
+1,239,195,237,0,2,0,0,0,128,0,-1--1--1,,1|(338,1234)|
+1,240,191,237,0,2,0,0,0,128,0,-1--1--1,,1|(772,1214)|
+1,241,8,36,1,0,0,0,0,128,0,-1--1--1,,1|(496,-31)|
+1,242,228,36,1,0,0,0,0,128,0,-1--1--1,,1|(688,220)|
+12,243,0,-29,1205,113,113,6,135,0,0,-1,0,0,0
 For >3mo, the data pull will always underestimate the actual # of patients, because we only include patients with 1 or more visits in this past quarter.
-10,244,Patients in Visits 2 to 7,1269,357,54,20,8,3,2,0,0,0,0,0
-1,245,11,244,0,2,0,0,0,128,0,-1--1--1,,1|(1271,566)|
-1,246,218,244,0,2,0,0,0,128,0,-1--1--1,,1|(1289,485)|
-1,247,203,244,0,2,0,0,0,128,0,-1--1--1,,1|(1289,401)|
-12,248,48,1133,604,10,8,0,3,0,0,-1,0,0,0
-1,249,220,248,100,0,0,22,0,0,0,-1--1--1,,1|(1159,603)|
-10,250,"User-defined %2-7-n-Done",891,794,47,20,8,3,1,2,-1,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-10,251,"% Go on to 2-7 in <3mo Data",850,473,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,252,251,39,0,0,0,0,0,128,0,-1--1--1,,1|(922,473)|
-1,253,250,126,0,1,0,0,0,128,0,-1--1--1,,1|(918,766)|
-10,254,"%Visit2-7-n-Done Data",801,732,61,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,255,254,126,0,0,0,0,0,128,0,-1--1--1,,1|(870,732)|
-10,256,"User-defined % Go on to 2-7 in <3mo",905,535,73,20,8,3,1,2,-1,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,257,256,39,0,1,0,0,0,128,0,-1--1--1,,1|(950,508)|
-10,258,"%Visit2-7-n-More<3mo Data",1497,663,80,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,259,258,233,0,0,0,0,0,128,0,-1--1--1,,1|(1398,670)|
-10,260,"User-defined %2-7-n-More<3mo",1641,696,66,20,8,3,1,2,-1,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,261,260,233,0,1,0,0,0,128,0,-1--1--1,,1|(1477,686)|
-10,262,"User-defined %Visit1<3mo and More",163,872,79,20,8,3,1,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-10,263,"%Visit1<3mo and More Data",8,945,60,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,264,262,83,0,1,0,0,0,128,0,-1--1--1,,1|(162,903)|
-1,265,263,83,0,0,0,0,0,128,0,-1--1--1,,1|(77,946)|
-10,266,"User-defined %Visit8PL-n-Done",2069,834,61,20,8,3,1,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-10,267,"%Visit8PL-n-Done Data",2222,762,61,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,268,267,178,0,0,0,0,0,128,0,-1--1--1,,1|(2142,762)|
-1,269,266,178,0,1,0,0,0,128,0,-1--1--1,,1|(2069,806)|
-10,270,"From1-PL3mo Median Time in Lower Q",761,1065,73,20,8,3,0,0,0,0,0,0
-10,271,"From1-PL3mo Median Time in Mid Qs",778,1183,73,20,8,3,0,0,0,0,0,0
-10,272,"From1-PL3mo Median Time in Upper Q",785,1295,73,20,8,3,0,0,0,0,0,0
-1,273,270,50,0,0,0,0,0,128,0,-1--1--1,,1|(711,1091)|
-1,274,271,62,0,0,0,0,0,128,0,-1--1--1,,1|(717,1210)|
-1,275,272,74,0,0,0,0,0,128,0,-1--1--1,,1|(726,1323)|
-10,276,Time to Percieve Supply for New Pts,356,432,63,20,8,3,0,0,0,0,0,0
-10,277,Percieved New Pt Appt Supply,302,360,46,24,3,131,0,0,0,0,0,0
-1,278,188,277,0,0,0,0,0,128,0,-1--1--1,,1|(223,359)|
-1,279,276,277,0,0,0,0,0,128,0,-1--1--1,,1|(334,403)|
-1,280,277,187,0,0,0,0,0,128,0,-1--1--1,,1|(377,360)|
-10,281,Graduation Rate,2073,686,54,11,8,3,0,0,0,0,0,0
-1,282,35,281,0,0,0,0,0,128,0,-1--1--1,,1|(1980,665)|
-1,283,178,281,0,0,0,0,0,128,0,-1--1--1,,1|(2070,726)|
-10,284,"Percent Change Duration of Pts in Care >3mo",1575,908,75,30,8,3,1,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,285,284,272,0,1,0,0,0,128,0,-1--1--1,,1|(1175,1103)|
-1,286,284,271,0,1,0,0,0,128,0,-1--1--1,,1|(1174,1045)|
-1,287,284,270,0,1,0,0,0,128,0,-1--1--1,,1|(1173,984)|
-1,288,284,123,0,1,0,0,0,128,0,-1--1--1,,1|(1546,1100)|
-1,289,284,109,0,1,0,0,0,128,0,-1--1--1,,1|(1539,1046)|
-1,290,284,95,0,1,0,0,0,128,0,-1--1--1,,1|(1537,984)|
-1,291,284,175,0,1,0,0,0,128,0,-1--1--1,,1|(1952,1091)|
-1,292,284,161,0,1,0,0,0,128,0,-1--1--1,,1|(1943,1034)|
-1,293,284,147,0,1,0,0,0,128,0,-1--1--1,,1|(1929,970)|
-10,294,"From1-PL3mo Median Time in Lower Q Data",935,1063,73,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,295,"From1-PL3mo MedianTime in Mid Qs Data",946,1182,73,30,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,296,"From1-PL3mo Median Time in Upper Q Data",963,1294,73,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,297,294,270,0,0,0,0,0,128,0,-1--1--1,,1|(854,1063)|
-1,298,295,271,0,0,0,0,0,128,0,-1--1--1,,1|(869,1182)|
-1,299,296,272,0,0,0,0,0,128,0,-1--1--1,,1|(881,1294)|
-10,300,"From2-7-PL3mo Median Time in Lower Q Data",1686,1065,81,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,301,"From2-7-PL3mo Median Time in Mid Qs Data",1690,1189,81,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,302,"From2-7-PL3mo Median Time in Upper Q Data",1705,1297,81,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,303,300,95,0,0,0,0,0,128,0,-1--1--1,,1|(1598,1064)|
-1,304,301,109,0,0,0,0,0,128,0,-1--1--1,,1|(1599,1188)|
-1,305,302,123,0,0,0,0,0,128,0,-1--1--1,,1|(1617,1296)|
-10,306,"From8PL-PL3mo Median Time in Lower Q Data",2484,1036,81,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,307,"From8PL-PL3mo Median Time in Mid Qs Data",2488,1160,81,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,308,"From8PL-PL3mo Median Time in Upper Q Data",2503,1271,81,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-1,309,306,147,0,0,0,0,0,128,0,-1--1--1,,1|(2401,1036)|
-1,310,307,161,0,0,0,0,0,128,0,-1--1--1,,1|(2401,1160)|
-1,311,308,175,0,0,0,0,0,128,0,-1--1--1,,1|(2419,1271)|
-10,312,Time,993,542,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,313,312,39,0,3,0,0,0,64,0,-1--1--1,,1|(997,519)|
-10,314,Time,1082,814,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,315,314,126,0,3,0,0,0,64,0,-1--1--1,,1|(1028,780)|
-10,316,Time,1375,679,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,317,316,233,0,3,0,0,0,64,0,-1--1--1,,1|(1363,678)|
-10,318,Time,68,987,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,319,318,83,0,3,0,0,0,64,0,-1--1--1,,1|(97,974)|
-10,320,Time,2226,659,28,11,8,2,15,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,321,320,178,0,15,0,0,0,64,0,-1--1--1,,1|(2160,702)|
-1,322,323,1,4,0,0,22,0,0,0,-1--1--1,,1|(508,279)|
-11,323,44,477,279,6,8,34,3,0,0,1,0,0,0
-10,324,Starting Rate,477,298,44,11,40,3,0,0,-1,0,0,0
-1,325,187,324,1,0,0,0,0,128,0,-1--1--1,,1|(465,326)|
-10,326,"<3mo Visit 1 who can start 2",525,615,40,20,3,3,0,0,0,0,0,0
-12,327,48,362,606,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-12,328,48,689,614,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,329,331,328,4,0,0,22,0,0,0,-1--1--1,,1|(655,614)|
-1,330,331,326,100,0,0,22,0,0,0,-1--1--1,,1|(592,614)|
-11,331,48,625,614,6,8,34,3,0,0,1,0,0,0
-10,332,Ending 1 who go on,625,633,56,20,40,3,0,0,-1,0,0,0
-1,333,326,331,1,0,0,0,0,64,0,-1--1--1,,1|(579,586)|
-1,334,335,326,4,0,0,22,0,0,0,-1--1--1,,1|(456,607)|
-11,335,396,422,607,6,8,34,3,0,0,1,0,0,0
-10,336,Starting 1 who can start 2,422,635,64,20,40,3,0,0,-1,0,0,0
-1,337,8,331,1,0,0,0,0,128,0,-1--1--1,,1|(640,602)|
-10,338,Starting Psychotherapy who can start 2,439,532,78,20,8,131,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,339,Percieved New Pt Appt Supply who can start 2,306,511,52,26,3,131,0,0,0,0,0,0
-1,340,339,338,0,0,0,0,0,128,0,-1--1--1,,1|(352,519)|
-1,341,338,335,0,0,0,0,0,128,0,-1--1--1,,1|(430,569)|
-1,342,185,338,0,0,0,0,0,128,0,-1--1--1,,1|(525,486)|
-1,343,186,338,0,0,0,0,0,128,0,-1--1--1,,1|(467,473)|
-1,344,276,339,0,0,0,0,0,128,0,-1--1--1,,1|(336,462)|
-10,345,Supply Available for New Pts who can start 2nd visit,121,511,93,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,346,345,339,0,0,0,0,0,128,0,-1--1--1,,1|(227,511)|
-1,347,332,208,1,0,0,0,0,64,0,-1--1--1,,1|(904,600)|
-1,348,332,221,0,0,0,0,0,64,0,-1--1--1,,1|(885,632)|
-1,349,332,16,1,0,0,0,0,64,0,-1--1--1,,1|(914,663)|
-10,350,Sankey One and More Laters,523,1683,55,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,351,FINAL TIME,537,1714,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,352,351,350,0,2,0,0,0,64,0,-1--1--1,,1|(539,1703)|
-1,353,70,350,0,2,0,0,0,64,0,-1--1--1,,1|(507,1515)|
-1,354,46,350,0,2,0,0,0,64,0,-1--1--1,,1|(502,1399)|
-1,355,58,350,0,2,0,0,0,64,0,-1--1--1,,1|(502,1458)|
-10,356,Time,537,1714,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,357,356,350,0,2,0,0,0,64,0,-1--1--1,,1|(539,1703)|
-10,358,Sankey Initiators who quit,1291,1699,56,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,359,FINAL TIME,1291,1730,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,360,359,358,0,2,0,0,0,64,0,-1--1--1,,1|(1291,1719)|
-1,361,208,358,0,2,0,0,0,64,0,-1--1--1,,1|(1242,1072)|
-10,362,Time,1291,1730,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,363,362,358,0,2,0,0,0,64,0,-1--1--1,,1|(1291,1719)|
-10,364,Sankey Graduators,1621,1711,37,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,365,FINAL TIME,1679,1814,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,366,365,364,0,2,0,0,0,64,0,-1--1--1,,1|(1655,1773)|
-1,367,221,364,0,2,0,0,0,64,0,-1--1--1,,1|(1397,1164)|
-10,368,Time,1679,1814,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,369,368,364,0,2,0,0,0,64,0,-1--1--1,,1|(1655,1773)|
-1,370,178,364,0,2,0,0,0,64,0,-1--1--1,,1|(1847,1231)|
-10,371,Sankey Initiators who Get More Later,1948,1723,72,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,372,FINAL TIME,1948,1754,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,373,372,371,0,2,0,0,0,64,0,-1--1--1,,1|(1948,1743)|
-1,374,16,371,0,2,0,0,0,64,0,-1--1--1,,1|(1555,1261)|
-10,375,Time,1948,1754,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,376,375,371,0,2,0,0,0,64,0,-1--1--1,,1|(1948,1743)|
-10,377,Sankey Completers who Get More Later,2164,1716,67,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-1,378,178,377,0,2,0,0,0,64,0,-1--1--1,,1|(2115,1233)|
-10,379,FINAL TIME,2164,1747,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,380,379,377,0,2,0,0,0,64,0,-1--1--1,,1|(2164,1736)|
-1,381,221,377,0,2,0,0,0,64,0,-1--1--1,,1|(1667,1168)|
-10,382,Time,2164,1747,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,383,382,377,0,2,0,0,0,64,0,-1--1--1,,1|(2164,1736)|
-10,384,Sankey Initaitors,889,894,55,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,385,FINAL TIME,989,924,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,386,385,384,0,2,0,0,0,64,0,-1--1--1,,1|(945,910)|
-1,387,208,384,0,2,0,0,0,64,0,-1--1--1,,1|(1043,675)|
-1,388,221,384,0,2,0,0,0,64,0,-1--1--1,,1|(1035,762)|
-1,389,16,384,0,2,0,0,0,64,0,-1--1--1,,1|(1023,848)|
-10,390,Time,889,925,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,391,390,384,0,2,0,0,0,64,0,-1--1--1,,1|(889,916)|
-10,392,Sankey Completers,1713,834,39,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,393,FINAL TIME,1745,883,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,394,393,392,0,2,0,0,0,64,0,-1--1--1,,1|(1735,868)|
-1,395,221,392,0,2,0,0,0,64,0,-1--1--1,,1|(1446,732)|
-10,396,Time,1678,882,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,397,396,392,0,2,0,0,0,64,0,-1--1--1,,1|(1687,868)|
-10,398,Sankey One and Dones,784,1679,55,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-1,399,83,398,0,2,0,0,0,64,0,-1--1--1,,1|(467,1308)|
-1,400,39,398,0,2,0,0,0,128,0,-1--1--1,,1|(897,1070)|
-10,401,Sankey E2,722,892,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-1,402,384,401,0,2,0,0,0,128,0,-1--1--1,,1|(802,893)|
-10,403,"Sankey One n Dones + Initiators + One n More Laters",241,1273,68,42,8,131,2,2,0,0,0,0,-1--1--1,0-0-0,|10||128-0-128
-1,404,384,403,0,2,0,0,0,64,0,-1--1--1,,1|(596,1065)|
-1,405,350,403,0,2,0,0,0,128,0,-1--1--1,,1|(393,1494)|
-1,406,398,403,0,2,0,0,0,128,0,-1--1--1,,1|(533,1491)|
-10,407,FINAL TIME,170,1175,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,408,407,403,0,2,0,0,0,64,0,-1--1--1,,1|(189,1202)|
-10,409,Time,261,1181,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,410,409,403,0,2,0,0,0,64,0,-1--1--1,,1|(256,1204)|
-10,411,FINAL TIME,421,1795,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-10,412,Time,421,1795,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,413,403,401,0,2,0,0,0,128,0,-1--1--1,,1|(495,1071)|
-10,414,FINAL TIME,773,851,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,415,414,401,0,2,0,0,0,64,0,-1--1--1,,1|(753,867)|
-10,416,Time,690,849,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,417,416,401,0,2,0,0,0,64,0,-1--1--1,,1|(701,864)|
-10,418,Sankey E3,782,1792,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-1,419,398,418,0,2,0,0,0,128,0,-1--1--1,,1|(783,1733)|
-1,420,403,418,0,2,0,0,0,128,0,-1--1--1,,1|(521,1543)|
-10,421,FINAL TIME,782,1823,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,422,421,418,0,2,0,0,0,64,0,-1--1--1,,1|(782,1814)|
-10,423,Time,782,1823,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,424,423,418,0,2,0,0,0,64,0,-1--1--1,,1|(782,1814)|
-10,425,Sankey E4,455,1743,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-1,426,350,425,0,2,0,0,0,128,0,-1--1--1,,1|(489,1712)|
-1,427,403,425,0,2,0,0,0,128,0,-1--1--1,,1|(351,1517)|
-1,428,412,425,0,2,0,0,0,128,0,-1--1--1,,1|(433,1774)|
-1,429,411,425,0,2,0,0,0,128,0,-1--1--1,,1|(433,1774)|
-10,430,"% One-n-Dones",810,313,37,18,8,131,1,0,0,0,0,0
-1,431,39,430,1,1,0,0,0,64,0,-1--1--1,,1|(974,381)|
-10,432,Sankey E5,1227,1762,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-1,433,358,432,0,2,0,0,0,128,0,-1--1--1,,1|(1259,1730)|
-1,434,384,432,0,2,0,0,0,128,0,-1--1--1,,1|(1054,1321)|
-10,435,FINAL TIME,1227,1793,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,436,435,432,0,2,0,0,0,64,0,-1--1--1,,1|(1227,1784)|
-10,437,Time,1227,1793,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,438,437,432,0,2,0,0,0,64,0,-1--1--1,,1|(1227,1784)|
-10,439,Sankey E6,1855,1802,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,440,FINAL TIME,1855,1833,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,441,440,439,0,2,0,0,0,64,0,-1--1--1,,1|(1855,1824)|
-1,442,384,439,0,2,0,0,0,64,0,-1--1--1,,1|(1366,1343)|
-1,443,371,439,0,2,0,0,0,64,0,-1--1--1,,1|(1901,1762)|
-10,444,Time,1855,1833,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,445,444,439,0,2,0,0,0,64,0,-1--1--1,,1|(1855,1824)|
-10,446,Sankey E7,1589,817,39,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,447,FINAL TIME,1595,856,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,448,447,446,0,2,0,0,0,64,0,-1--1--1,,1|(1593,843)|
-1,449,392,446,0,2,0,0,0,64,0,-1--1--1,,1|(1657,826)|
-1,450,384,446,0,2,0,0,0,64,0,-1--1--1,,1|(1240,855)|
-10,451,Time,1542,855,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,452,451,446,0,2,0,0,0,64,0,-1--1--1,,1|(1559,840)|
-10,453,Sankey E8,1486,1782,39,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,454,FINAL TIME,1486,1813,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,455,454,453,0,2,0,0,0,64,0,-1--1--1,,1|(1486,1804)|
-1,456,392,453,0,2,0,0,0,64,0,-1--1--1,,1|(1600,1305)|
-1,457,364,453,0,2,0,0,0,64,0,-1--1--1,,1|(1551,1747)|
-10,458,Time,1486,1813,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,459,458,453,0,2,0,0,0,64,0,-1--1--1,,1|(1486,1804)|
-10,460,Sankey E9,2033,1789,39,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,461,FINAL TIME,2033,1820,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,462,461,460,0,2,0,0,0,64,0,-1--1--1,,1|(2033,1811)|
-1,463,392,460,0,2,0,0,0,64,0,-1--1--1,,1|(1871,1309)|
-1,464,377,460,0,2,0,0,0,64,0,-1--1--1,,1|(2096,1753)|
-10,465,Time,2033,1820,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,466,465,460,0,2,0,0,0,64,0,-1--1--1,,1|(2033,1811)|
-10,467,FINAL TIME,784,1719,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,468,467,398,0,2,0,0,0,64,0,-1--1--1,,1|(784,1710)|
-10,469,Time,784,1719,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,470,469,398,0,2,0,0,0,64,0,-1--1--1,,1|(784,1710)|
-1,471,324,398,0,2,0,0,0,64,0,-1--1--1,,1|(627,977)|
-10,472,Experiment Week,1054,559,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,473,472,39,0,3,0,0,0,64,0,-1--1--1,,1|(1034,523)|
-10,474,Experiment Week,106,1010,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,475,474,83,0,3,0,0,0,64,0,-1--1--1,,1|(128,984)|
-10,476,Experiment Week,1498,1104,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,477,476,95,0,3,0,0,0,64,0,-1--1--1,,1|(1498,1084)|
-10,478,Experiment Week,1502,1228,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,479,478,109,0,3,0,0,0,64,0,-1--1--1,,1|(1502,1208)|
-10,480,Experiment Week,1517,1336,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,481,480,123,0,3,0,0,0,64,0,-1--1--1,,1|(1517,1316)|
-10,482,Experiment Week,1014,813,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,483,482,126,0,3,0,0,0,64,0,-1--1--1,,1|(987,777)|
-10,484,Experiment Week,2219,698,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,485,484,178,0,3,0,0,0,64,0,-1--1--1,,1|(2148,728)|
-10,486,Experiment Week,1326,718,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,487,486,233,0,3,0,0,0,64,0,-1--1--1,,1|(1326,698)|
-10,488,Experiment Week,761,1105,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,489,488,270,0,3,0,0,0,64,0,-1--1--1,,1|(761,1085)|
-10,490,Experiment Week,778,1223,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,491,490,271,0,3,0,0,0,64,0,-1--1--1,,1|(778,1203)|
-10,492,Experiment Week,785,1335,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,493,492,272,0,3,0,0,0,64,0,-1--1--1,,1|(785,1315)|
-10,494,Ending After 1 Visit Rate,759,234,48,20,8,3,0,0,0,0,0,0
-1,495,7,494,0,0,0,0,0,128,0,-1--1--1,,1|(705,278)|
-1,496,430,494,0,1,0,0,0,128,0,-1--1--1,,1|(788,280)|
-10,497,"Continuing Treatment Rate (After 3 Months) From First Visit",350,948,94,30,8,3,0,0,0,0,0,0
-1,498,332,497,0,0,0,0,0,128,0,-1--1--1,,1|(496,780)|
-1,499,83,497,0,0,0,0,0,128,0,-1--1--1,,1|(231,948)|
-1,500,497,45,1,0,0,0,0,128,0,-1--1--1,,1|(388,1028)|
-1,501,497,57,1,0,0,0,0,128,0,-1--1--1,,1|(350,1089)|
-1,502,497,69,1,0,0,0,0,128,0,-1--1--1,,1|(314,1160)|
-10,503,Ending Rate,1453,1569,41,11,8,3,1,0,0,0,0,0
-1,504,122,503,0,1,0,0,0,128,0,-1--1--1,,1|(1449,1465)|
-1,505,108,503,0,1,0,0,0,128,0,-1--1--1,,1|(1444,1408)|
-1,506,94,503,0,1,0,0,0,128,0,-1--1--1,,1|(1443,1349)|
-1,507,174,503,0,1,0,0,0,128,0,-1--1--1,,1|(1852,1459)|
-1,508,160,503,0,1,0,0,0,128,0,-1--1--1,,1|(1843,1404)|
-1,509,146,503,0,1,0,0,0,128,0,-1--1--1,,1|(1846,1344)|
-1,510,75,503,0,1,0,0,0,128,0,-1--1--1,,1|(1068,1467)|
-1,511,63,503,0,1,0,0,0,128,0,-1--1--1,,1|(1071,1413)|
-1,512,51,503,0,1,0,0,0,128,0,-1--1--1,,1|(1068,1353)|
-10,513,Experiment Week,2304,1077,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,514,513,147,0,3,0,0,0,64,0,-1--1--1,,1|(2304,1057)|
-10,515,Experiment Week,2308,1201,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,516,515,161,0,3,0,0,0,64,0,-1--1--1,,1|(2308,1181)|
-10,517,Experiment Week,2323,1312,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,518,517,175,0,3,0,0,0,64,0,-1--1--1,,1|(2323,1292)|
-10,519,"%Visit1-n-Done",160,805,53,11,8,3,3,0,0,0,0,0
-1,520,263,519,0,3,0,0,0,128,0,-1--1--1,,1|(83,875)|
-1,521,251,519,0,3,0,0,0,128,0,-1--1--1,,1|(501,640)|
-10,522,"%Visit2-7<3mo and More",995,414,53,20,8,3,3,0,0,0,0,0
-1,523,254,522,0,3,0,0,0,64,0,-1--1--1,,1|(893,578)|
-1,524,258,522,0,3,0,0,0,64,0,-1--1--1,,1|(1252,541)|
-10,525,"%Visit8PL-n-More",2372,741,78,10,8,3,3,0,0,0,0,0
-1,526,267,525,1,3,0,0,0,128,0,-1--1--1,,1|(2298,734)|
-10,527,Starters who Quit,883,708,58,11,8,3,3,0,0,0,0,0
-1,528,251,527,0,3,0,0,0,64,0,-1--1--1,,1|(865,588)|
-1,529,263,527,0,3,0,0,0,64,0,-1--1--1,,1|(448,825)|
-10,530,Initators who Return Later,767,790,45,20,8,3,3,0,0,0,0,0
-1,531,254,530,0,3,0,0,0,64,0,-1--1--1,,1|(787,755)|
-1,532,258,530,0,3,0,0,0,64,0,-1--1--1,,1|(1121,727)|
-10,533,Completers who Return,2225,837,55,20,8,3,3,0,0,0,0,0
-1,534,267,533,0,3,0,0,0,64,0,-1--1--1,,1|(2222,792)|
-10,535,Initiation Rate,1147,295,47,11,8,131,2,0,0,0,0,0
-1,536,207,535,0,2,0,0,0,128,0,-1--1--1,,1|(1175,372)|
-1,537,220,535,0,2,0,0,0,128,0,-1--1--1,,1|(1165,458)|
-1,538,15,535,0,2,0,0,0,128,0,-1--1--1,,1|(1156,538)|
-10,539,"Continuing Treatment Rate (After 3 Months) from Over 7 Visits",1877,764,97,30,8,3,0,0,0,0,0,0
-1,540,35,539,0,0,0,0,0,128,0,-1--1--1,,1|(1873,695)|
-1,541,178,539,0,0,0,0,0,128,0,-1--1--1,,1|(2008,763)|
-1,542,539,140,1,0,0,0,0,128,0,-1--1--1,,1|(1878,972)|
-1,543,539,154,1,0,0,0,0,128,0,-1--1--1,,1|(1841,988)|
-1,544,539,168,1,0,0,0,0,128,0,-1--1--1,,1|(1826,1140)|
-10,545,"%Visit1<3mo and More",883,235,50,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|0||128-128-128
-1,546,545,430,0,1,0,0,0,128,0,-1--1--1,,1|(850,269)|
-1,547,335,327,100,0,0,22,0,0,0,-1--1--1,,1|(394,607)|
-1,548,323,2,100,0,0,22,0,0,0,-1--1--1,,1|(446,279)|
+10,244,Patients in Visits 2 to 7,269,97,54,20,8,3,2,0,0,0,0,0
+1,245,11,244,0,2,0,0,0,128,0,-1--1--1,,1|(271,306)|
+1,246,218,244,0,2,0,0,0,128,0,-1--1--1,,1|(289,225)|
+1,247,203,244,0,2,0,0,0,128,0,-1--1--1,,1|(289,142)|
+12,248,48,133,344,10,8,0,3,0,0,-1,0,0,0
+1,249,220,248,100,0,0,22,0,0,0,-1--1--1,,1|(159,343)|
+10,250,"User-defined Initiators Who Quit Early %",-109,534,74,20,8,3,1,2,-1,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+10,251,"Starters Who Initiate %",-150,213,44,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,252,251,39,0,0,0,0,0,128,0,-1--1--1,,1|(-89,213)|
+1,253,250,126,0,1,0,0,0,128,0,-1--1--1,,1|(-83,508)|
+10,254,"Initiators Who Quit Early %",-199,472,63,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,255,254,126,0,0,0,0,0,128,0,-1--1--1,,1|(-133,472)|
+10,256,"User-defined Starters Who Initiate %",-95,275,71,20,8,3,1,2,-1,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,257,256,39,0,1,0,0,0,128,0,-1--1--1,,1|(-50,248)|
+10,258,"Initiators Who Complete %",497,403,47,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,259,258,233,0,0,0,0,0,128,0,-1--1--1,,1|(429,407)|
+10,260,"User-defined Initiators Who Complete %",641,436,74,20,8,3,1,2,-1,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,261,260,233,0,1,0,0,0,128,0,-1--1--1,,1|(488,426)|
+10,262,"User-defined Starters Who Return Later %",-837,612,71,20,8,3,1,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+10,263,"Starters Who Return Later %",-992,685,52,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,264,262,83,0,1,0,0,0,128,0,-1--1--1,,1|(-837,643)|
+1,265,263,83,0,0,0,0,0,128,0,-1--1--1,,1|(-930,686)|
+10,266,"User-defined Completers who Graduate %",1069,574,55,30,8,3,1,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+10,267,"Completers Who Graduate %",1222,502,56,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,268,267,178,0,0,0,0,0,128,0,-1--1--1,,1|(1155,502)|
+1,269,266,178,0,1,0,0,0,128,0,-1--1--1,,1|(1069,540)|
+10,270,From Starters Median Time in Lower Q,-239,805,72,20,8,3,0,0,0,0,0,0
+10,271,From Starters Median Time in Mid Qs,-222,923,72,20,8,3,0,0,0,0,0,0
+10,272,From Starters Median Time in Upper Q,-215,1035,72,20,8,3,0,0,0,0,0,0
+1,273,270,50,0,0,0,0,0,128,0,-1--1--1,,1|(-289,831)|
+1,274,271,62,0,0,0,0,0,128,0,-1--1--1,,1|(-283,950)|
+1,275,272,74,0,0,0,0,0,128,0,-1--1--1,,1|(-273,1062)|
+10,276,Time to Percieve Supply for New Pts,-644,172,63,20,8,3,0,0,0,0,0,0
+10,277,Percieved New pts appt Supply,-698,100,46,24,3,131,0,0,0,0,0,0
+1,278,188,277,0,0,0,0,0,128,0,-1--1--1,,1|(-776,100)|
+1,279,276,277,0,0,0,0,0,128,0,-1--1--1,,1|(-665,144)|
+1,280,277,187,0,0,0,0,0,128,0,-1--1--1,,1|(-622,101)|
+10,281,Graduation Rate,1073,426,54,11,8,3,0,0,0,0,0,0
+1,282,35,281,0,0,0,0,0,128,0,-1--1--1,,1|(967,403)|
+1,283,178,281,0,0,0,0,0,128,0,-1--1--1,,1|(1070,467)|
+10,284,Change in Engagement Time of Patients Past 3 Months,564,679,79,30,8,3,1,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,285,284,272,0,1,0,0,0,128,0,-1--1--1,,1|(169,859)|
+1,286,284,271,0,1,0,0,0,128,0,-1--1--1,,1|(170,800)|
+1,287,284,270,0,1,0,0,0,128,0,-1--1--1,,1|(165,740)|
+1,288,284,123,0,1,0,0,0,128,0,-1--1--1,,1|(540,855)|
+1,289,284,109,0,1,0,0,0,128,0,-1--1--1,,1|(533,801)|
+1,290,284,95,0,1,0,0,0,128,0,-1--1--1,,1|(531,740)|
+1,291,284,175,0,1,0,0,0,128,0,-1--1--1,,1|(948,847)|
+1,292,284,161,0,1,0,0,0,128,0,-1--1--1,,1|(934,789)|
+1,293,284,147,0,1,0,0,0,128,0,-1--1--1,,1|(926,726)|
+10,294,From Starters Median Time in Lower Q Data,-65,803,73,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,295,From Starters MedianTime in Mid Qs Data,-54,922,73,30,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,296,From Starters Median Time in Upper Q Data,-37,1034,72,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,297,294,270,0,0,0,0,0,128,0,-1--1--1,,1|(-146,803)|
+1,298,295,271,0,0,0,0,0,128,0,-1--1--1,,1|(-132,922)|
+1,299,296,272,0,0,0,0,0,128,0,-1--1--1,,1|(-119,1034)|
+10,300,From Initiators Median Time in Lower Q Data,686,805,75,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,301,From Initiators Median Time in Mid Qs Data,690,929,75,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,302,From Initiators Median Time in Upper Q Data,705,1037,75,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,303,300,95,0,0,0,0,0,128,0,-1--1--1,,1|(598,804)|
+1,304,301,109,0,0,0,0,0,128,0,-1--1--1,,1|(602,928)|
+1,305,302,123,0,0,0,0,0,128,0,-1--1--1,,1|(617,1036)|
+10,306,From Completers Median Time in Lower Q Data,1484,776,83,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,307,From Completers Median Time in Mid Qs Data,1488,900,83,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,308,From Completers Median Time in Upper Q Data,1503,1011,83,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+1,309,306,147,0,0,0,0,0,128,0,-1--1--1,,1|(1400,776)|
+1,310,307,161,0,0,0,0,0,128,0,-1--1--1,,1|(1400,900)|
+1,311,308,175,0,0,0,0,0,128,0,-1--1--1,,1|(1418,1011)|
+10,312,Time,-7,282,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,313,312,39,0,3,0,0,0,64,0,-1--1--1,,1|(-3,259)|
+10,314,Time,82,554,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,315,314,126,0,3,0,0,0,64,0,-1--1--1,,1|(31,521)|
+10,316,Time,375,419,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,317,316,233,0,3,0,0,0,64,0,-1--1--1,,1|(378,418)|
+10,318,Time,-932,727,28,11,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,319,318,83,0,3,0,0,0,64,0,-1--1--1,,1|(-902,714)|
+10,320,Time,1226,399,28,11,8,2,15,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,321,320,178,0,15,0,0,0,64,0,-1--1--1,,1|(1160,442)|
+1,322,323,1,4,0,0,22,0,0,0,-1--1--1,,1|(-491,19)|
+11,323,44,-523,19,6,8,34,3,0,0,1,0,0,0
+10,324,Starting Rate,-523,38,44,11,40,3,0,0,-1,0,0,0
+1,325,187,324,1,0,0,0,0,128,0,-1--1--1,,1|(-535,66)|
+10,326,"<3mo Visit 1 who can start 2",-475,355,40,20,3,3,0,0,0,0,0,0
+12,327,48,-638,346,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+12,328,48,-311,354,10,8,0,3,0,40,-1,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,329,331,328,4,0,0,22,0,0,0,-1--1--1,,1|(-345,354)|
+1,330,331,326,100,0,0,22,0,0,0,-1--1--1,,1|(-408,354)|
+11,331,48,-375,354,6,8,34,3,0,0,1,0,0,0
+10,332,Ending who can Initiate,-375,373,54,20,40,3,0,0,-1,0,0,0
+1,333,326,331,1,0,0,0,0,64,0,-1--1--1,,1|(-421,326)|
+1,334,335,326,4,0,0,22,0,0,0,-1--1--1,,1|(-543,347)|
+11,335,572,-578,347,6,8,34,3,0,0,1,0,0,0
+10,336,Starting Rate who can Initiate,-578,375,61,20,40,3,0,0,-1,0,0,0
+1,337,8,331,1,0,0,0,0,128,0,-1--1--1,,1|(-360,342)|
+10,338,Starting Psychotherapy who can start 2,-561,272,78,20,8,131,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,339,Percieved New pts appt Supply who can start 2,-694,251,52,26,3,131,0,0,0,0,0,0
+1,340,339,338,0,0,0,0,0,128,0,-1--1--1,,1|(-647,259)|
+1,341,338,335,0,0,0,0,0,128,0,-1--1--1,,1|(-568,309)|
+1,342,185,338,0,0,0,0,0,128,0,-1--1--1,,1|(-474,226)|
+1,343,186,338,0,0,0,0,0,128,0,-1--1--1,,1|(-532,213)|
+1,344,276,339,0,0,0,0,0,128,0,-1--1--1,,1|(-662,202)|
+10,345,Supply Available for New Pts who can start 2nd visit,-879,251,93,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,346,345,339,0,0,0,0,0,128,0,-1--1--1,,1|(-773,251)|
+1,347,332,208,1,0,0,0,0,64,0,-1--1--1,,1|(-96,340)|
+1,348,332,221,0,0,0,0,0,64,0,-1--1--1,,1|(-109,372)|
+1,349,332,16,1,0,0,0,0,64,0,-1--1--1,,1|(-86,403)|
+10,350,Sankey One and More Laters,-477,1423,55,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,351,FINAL TIME,-463,1454,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,352,351,350,0,2,0,0,0,64,0,-1--1--1,,1|(-467,1443)|
+1,353,70,350,0,2,0,0,0,64,0,-1--1--1,,1|(-491,1255)|
+1,354,46,350,0,2,0,0,0,64,0,-1--1--1,,1|(-497,1139)|
+1,355,58,350,0,2,0,0,0,64,0,-1--1--1,,1|(-496,1198)|
+10,356,Time,-463,1454,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,357,356,350,0,2,0,0,0,64,0,-1--1--1,,1|(-467,1443)|
+10,358,Sankey Initiators who quit,291,1439,56,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,359,FINAL TIME,291,1470,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,360,359,358,0,2,0,0,0,64,0,-1--1--1,,1|(291,1459)|
+1,361,208,358,0,2,0,0,0,64,0,-1--1--1,,1|(242,812)|
+10,362,Time,291,1470,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,363,362,358,0,2,0,0,0,64,0,-1--1--1,,1|(291,1459)|
+10,364,Sankey Graduators,621,1451,37,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,365,FINAL TIME,679,1554,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,366,365,364,0,2,0,0,0,64,0,-1--1--1,,1|(655,1513)|
+1,367,221,364,0,2,0,0,0,64,0,-1--1--1,,1|(397,904)|
+10,368,Time,679,1554,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,369,368,364,0,2,0,0,0,64,0,-1--1--1,,1|(655,1513)|
+1,370,178,364,0,2,0,0,0,64,0,-1--1--1,,1|(847,970)|
+10,371,Sankey Initiators who Get More Later,948,1463,72,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,372,FINAL TIME,948,1494,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,373,372,371,0,2,0,0,0,64,0,-1--1--1,,1|(948,1483)|
+1,374,16,371,0,2,0,0,0,64,0,-1--1--1,,1|(551,996)|
+10,375,Time,948,1494,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,376,375,371,0,2,0,0,0,64,0,-1--1--1,,1|(948,1483)|
+10,377,Sankey Completers who Get More Later,1164,1456,67,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+1,378,178,377,0,2,0,0,0,64,0,-1--1--1,,1|(1115,972)|
+10,379,FINAL TIME,1164,1487,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,380,379,377,0,2,0,0,0,64,0,-1--1--1,,1|(1164,1476)|
+1,381,221,377,0,2,0,0,0,64,0,-1--1--1,,1|(667,908)|
+10,382,Time,1164,1487,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,383,382,377,0,2,0,0,0,64,0,-1--1--1,,1|(1164,1476)|
+10,384,Sankey Initaitors,-111,634,55,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,385,FINAL TIME,-11,664,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,386,385,384,0,2,0,0,0,64,0,-1--1--1,,1|(-55,650)|
+1,387,208,384,0,2,0,0,0,64,0,-1--1--1,,1|(43,415)|
+1,388,221,384,0,2,0,0,0,64,0,-1--1--1,,1|(35,502)|
+1,389,16,384,0,2,0,0,0,64,0,-1--1--1,,1|(20,589)|
+10,390,Time,-111,665,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,391,390,384,0,2,0,0,0,64,0,-1--1--1,,1|(-111,656)|
+10,392,Sankey Completers,713,574,39,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,393,FINAL TIME,745,623,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,394,393,392,0,2,0,0,0,64,0,-1--1--1,,1|(735,608)|
+1,395,221,392,0,2,0,0,0,64,0,-1--1--1,,1|(446,472)|
+10,396,Time,678,622,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,397,396,392,0,2,0,0,0,64,0,-1--1--1,,1|(687,608)|
+10,398,Sankey One and Dones,-216,1419,55,20,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+1,399,83,398,0,2,0,0,0,64,0,-1--1--1,,1|(-532,1048)|
+1,400,39,398,0,2,0,0,0,128,0,-1--1--1,,1|(-103,810)|
+10,401,Sankey E2,-278,632,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+1,402,384,401,0,2,0,0,0,128,0,-1--1--1,,1|(-198,633)|
+10,403,"Sankey One n Dones + Initiators + One n More Laters",-759,1013,68,42,8,131,2,2,0,0,0,0,-1--1--1,0-0-0,|10||128-0-128
+1,404,384,403,0,2,0,0,0,64,0,-1--1--1,,1|(-403,805)|
+1,405,350,403,0,2,0,0,0,128,0,-1--1--1,,1|(-606,1234)|
+1,406,398,403,0,2,0,0,0,128,0,-1--1--1,,1|(-466,1231)|
+10,407,FINAL TIME,-830,915,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,408,407,403,0,2,0,0,0,64,0,-1--1--1,,1|(-810,942)|
+10,409,Time,-739,921,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,410,409,403,0,2,0,0,0,64,0,-1--1--1,,1|(-743,944)|
+10,411,FINAL TIME,-579,1535,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,412,Time,-579,1535,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,413,403,401,0,2,0,0,0,128,0,-1--1--1,,1|(-504,811)|
+10,414,FINAL TIME,-227,591,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,415,414,401,0,2,0,0,0,64,0,-1--1--1,,1|(-247,607)|
+10,416,Time,-310,589,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,417,416,401,0,2,0,0,0,64,0,-1--1--1,,1|(-299,604)|
+10,418,Sankey E3,-218,1532,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+1,419,398,418,0,2,0,0,0,128,0,-1--1--1,,1|(-217,1473)|
+1,420,403,418,0,2,0,0,0,128,0,-1--1--1,,1|(-478,1283)|
+10,421,FINAL TIME,-218,1563,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,422,421,418,0,2,0,0,0,64,0,-1--1--1,,1|(-218,1554)|
+10,423,Time,-218,1563,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,424,423,418,0,2,0,0,0,64,0,-1--1--1,,1|(-218,1554)|
+10,425,Sankey E4,-545,1483,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+1,426,350,425,0,2,0,0,0,128,0,-1--1--1,,1|(-510,1452)|
+1,427,403,425,0,2,0,0,0,128,0,-1--1--1,,1|(-647,1257)|
+1,428,412,425,0,2,0,0,0,128,0,-1--1--1,,1|(-565,1514)|
+1,429,411,425,0,2,0,0,0,128,0,-1--1--1,,1|(-565,1514)|
+10,430,"% One-n-Dones",-190,53,37,18,8,131,1,0,0,0,0,0
+1,431,39,430,1,1,0,0,0,64,0,-1--1--1,,1|(-26,121)|
+10,432,Sankey E5,227,1502,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+1,433,358,432,0,2,0,0,0,128,0,-1--1--1,,1|(259,1470)|
+1,434,384,432,0,2,0,0,0,128,0,-1--1--1,,1|(54,1061)|
+10,435,FINAL TIME,227,1533,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,436,435,432,0,2,0,0,0,64,0,-1--1--1,,1|(227,1524)|
+10,437,Time,227,1533,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,438,437,432,0,2,0,0,0,64,0,-1--1--1,,1|(227,1524)|
+10,439,Sankey E6,855,1542,35,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,440,FINAL TIME,855,1573,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,441,440,439,0,2,0,0,0,64,0,-1--1--1,,1|(855,1564)|
+1,442,384,439,0,2,0,0,0,64,0,-1--1--1,,1|(366,1083)|
+1,443,371,439,0,2,0,0,0,64,0,-1--1--1,,1|(901,1502)|
+10,444,Time,855,1573,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,445,444,439,0,2,0,0,0,64,0,-1--1--1,,1|(855,1564)|
+10,446,Sankey E7,589,557,39,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,447,FINAL TIME,595,596,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,448,447,446,0,2,0,0,0,64,0,-1--1--1,,1|(593,583)|
+1,449,392,446,0,2,0,0,0,64,0,-1--1--1,,1|(657,566)|
+1,450,384,446,0,2,0,0,0,64,0,-1--1--1,,1|(240,595)|
+10,451,Time,542,595,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,452,451,446,0,2,0,0,0,64,0,-1--1--1,,1|(559,580)|
+10,453,Sankey E8,486,1522,39,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,454,FINAL TIME,486,1553,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,455,454,453,0,2,0,0,0,64,0,-1--1--1,,1|(486,1544)|
+1,456,392,453,0,2,0,0,0,64,0,-1--1--1,,1|(600,1045)|
+1,457,364,453,0,2,0,0,0,64,0,-1--1--1,,1|(551,1487)|
+10,458,Time,486,1553,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,459,458,453,0,2,0,0,0,64,0,-1--1--1,,1|(486,1544)|
+10,460,Sankey E9,1033,1529,39,11,8,3,2,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,461,FINAL TIME,1033,1560,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,462,461,460,0,2,0,0,0,64,0,-1--1--1,,1|(1033,1551)|
+1,463,392,460,0,2,0,0,0,64,0,-1--1--1,,1|(871,1049)|
+1,464,377,460,0,2,0,0,0,64,0,-1--1--1,,1|(1096,1493)|
+10,465,Time,1033,1560,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,466,465,460,0,2,0,0,0,64,0,-1--1--1,,1|(1033,1551)|
+10,467,FINAL TIME,-216,1459,49,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,468,467,398,0,2,0,0,0,64,0,-1--1--1,,1|(-216,1450)|
+10,469,Time,-216,1459,28,11,8,2,2,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,470,469,398,0,2,0,0,0,64,0,-1--1--1,,1|(-216,1450)|
+1,471,324,398,0,2,0,0,0,64,0,-1--1--1,,1|(-372,717)|
+10,472,Experiment wk,54,299,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,473,472,39,0,3,0,0,0,64,0,-1--1--1,,1|(34,263)|
+10,474,Experiment wk,-894,750,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,475,474,83,0,3,0,0,0,64,0,-1--1--1,,1|(-871,724)|
+10,476,Experiment wk,498,844,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,477,476,95,0,3,0,0,0,64,0,-1--1--1,,1|(498,824)|
+10,478,Experiment wk,502,968,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,479,478,109,0,3,0,0,0,64,0,-1--1--1,,1|(502,948)|
+10,480,Experiment wk,517,1076,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,481,480,123,0,3,0,0,0,64,0,-1--1--1,,1|(517,1056)|
+10,482,Experiment wk,14,553,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,483,482,126,0,3,0,0,0,64,0,-1--1--1,,1|(-12,518)|
+10,484,Experiment wk,1219,438,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,485,484,178,0,3,0,0,0,64,0,-1--1--1,,1|(1151,467)|
+10,486,Experiment wk,326,458,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,487,486,233,0,3,0,0,0,64,0,-1--1--1,,1|(326,444)|
+10,488,Experiment wk,-239,845,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,489,488,270,0,3,0,0,0,64,0,-1--1--1,,1|(-239,825)|
+10,490,Experiment wk,-222,963,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,491,490,271,0,3,0,0,0,64,0,-1--1--1,,1|(-222,943)|
+10,492,Experiment wk,-215,1075,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,493,492,272,0,3,0,0,0,64,0,-1--1--1,,1|(-215,1055)|
+10,494,Ending After 1 Visit Rate,-241,-26,48,20,8,3,0,0,0,0,0,0
+1,495,7,494,0,0,0,0,0,128,0,-1--1--1,,1|(-295,19)|
+1,496,430,494,0,1,0,0,0,128,0,-1--1--1,,1|(-212,21)|
+10,497,"Continuing Treatment Rate (After 3 Months) From First Visit",-650,688,94,30,8,3,0,0,0,0,0,0
+1,498,332,497,0,0,0,0,0,128,0,-1--1--1,,1|(-502,520)|
+1,499,83,497,0,0,0,0,0,128,0,-1--1--1,,1|(-765,688)|
+1,500,497,45,1,0,0,0,0,128,0,-1--1--1,,1|(-612,768)|
+1,501,497,57,1,0,0,0,0,128,0,-1--1--1,,1|(-650,829)|
+1,502,497,69,1,0,0,0,0,128,0,-1--1--1,,1|(-686,900)|
+10,503,Ending Rate,453,1309,41,11,8,3,1,0,0,0,0,0
+1,504,122,503,0,1,0,0,0,128,0,-1--1--1,,1|(449,1205)|
+1,505,108,503,0,1,0,0,0,128,0,-1--1--1,,1|(444,1148)|
+1,506,94,503,0,1,0,0,0,128,0,-1--1--1,,1|(443,1089)|
+1,507,174,503,0,1,0,0,0,128,0,-1--1--1,,1|(851,1199)|
+1,508,160,503,0,1,0,0,0,128,0,-1--1--1,,1|(843,1144)|
+1,509,146,503,0,1,0,0,0,128,0,-1--1--1,,1|(846,1084)|
+1,510,75,503,0,1,0,0,0,128,0,-1--1--1,,1|(68,1207)|
+1,511,63,503,0,1,0,0,0,128,0,-1--1--1,,1|(70,1152)|
+1,512,51,503,0,1,0,0,0,128,0,-1--1--1,,1|(68,1093)|
+10,513,Experiment wk,1304,817,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,514,513,147,0,3,0,0,0,64,0,-1--1--1,,1|(1304,797)|
+10,515,Experiment wk,1308,941,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,516,515,161,0,3,0,0,0,64,0,-1--1--1,,1|(1308,921)|
+10,517,Experiment wk,1323,1052,44,20,8,2,3,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,518,517,175,0,3,0,0,0,64,0,-1--1--1,,1|(1323,1032)|
+10,519,"%Visit1-n-Done",-840,545,53,11,8,3,3,0,0,0,0,0
+1,520,263,519,0,3,0,0,0,128,0,-1--1--1,,1|(-916,615)|
+1,521,251,519,0,3,0,0,0,128,0,-1--1--1,,1|(-497,380)|
+10,522,"%Visit2-7<3mo and More",-5,154,53,20,8,3,3,0,0,0,0,0
+1,523,254,522,0,3,0,0,0,64,0,-1--1--1,,1|(-107,318)|
+1,524,258,522,0,3,0,0,0,64,0,-1--1--1,,1|(252,281)|
+10,525,"%Visit8PL-n-More",1372,481,78,10,8,3,3,0,0,0,0,0
+1,526,267,525,1,3,0,0,0,128,0,-1--1--1,,1|(1298,474)|
+10,527,"Starters who Quit %",-189,423,43,20,8,3,3,0,0,0,0,0
+1,528,251,527,0,3,0,0,0,64,0,-1--1--1,,1|(-169,311)|
+1,529,263,527,0,3,0,0,0,64,0,-1--1--1,,1|(-593,555)|
+10,530,Initators who Return Later,-233,530,45,20,8,3,3,0,0,0,0,0
+1,531,254,530,0,3,0,0,0,64,0,-1--1--1,,1|(-213,495)|
+1,532,258,530,0,3,0,0,0,64,0,-1--1--1,,1|(137,465)|
+10,533,Completers who Return,1225,577,55,20,8,3,3,0,0,0,0,0
+1,534,267,533,0,3,0,0,0,64,0,-1--1--1,,1|(1222,532)|
+10,535,Initiation Rate,147,35,47,11,8,131,2,0,0,0,0,0
+1,536,207,535,0,2,0,0,0,128,0,-1--1--1,,1|(175,113)|
+1,537,220,535,0,2,0,0,0,128,0,-1--1--1,,1|(165,199)|
+1,538,15,535,0,2,0,0,0,128,0,-1--1--1,,1|(156,278)|
+10,539,"Continuing Treatment Rate (After 3 Months) from Over 7 Visits",877,504,97,30,8,3,0,0,0,0,0,0
+1,540,35,539,0,0,0,0,0,128,0,-1--1--1,,1|(872,431)|
+1,541,178,539,0,0,0,0,0,128,0,-1--1--1,,1|(998,503)|
+1,542,539,140,1,0,0,0,0,128,0,-1--1--1,,1|(878,712)|
+1,543,539,154,1,0,0,0,0,128,0,-1--1--1,,1|(841,728)|
+1,544,539,168,1,0,0,0,0,128,0,-1--1--1,,1|(826,880)|
+10,545,"Actual Starters Who Return Later %",-117,-25,72,20,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,546,545,430,0,1,0,0,0,128,0,-1--1--1,,1|(-150,10)|
+1,547,335,327,100,0,0,22,0,0,0,-1--1--1,,1|(-606,347)|
+1,548,323,2,100,0,0,22,0,0,0,-1--1--1,,1|(-554,19)|
 \\\---/// Sketch information - do not modify anything except names
 V300  Do not put anything below this section - it will be ignored
 *Performance Measures
 $192-192-192,0,Meiryo|10||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,70,0
-10,1,Patients in First Visit,1225,835,77,16,8,130,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-10,2,"<3mo Visit 2-7-n-More>3mo",1193,706,65,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-10,3,Patients in Over 7 Visits,1186,606,68,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-10,4,"Total Pts <3months",950,678,35,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,5,1,4,0,0,0,0,0,128,0,-1--1--1,,1|(1097,761)|
-1,6,2,4,0,0,0,0,0,128,0,-1--1--1,,1|(1063,691)|
-1,7,3,4,0,0,0,0,0,128,0,-1--1--1,,1|(1058,644)|
-10,8,EBP Bronze Standard for Depression,939,-130,72,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
-10,9,EBP Gold Standard for Depression,1307,-129,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,10,Total Pts in Psych,1066,878,57,11,8,3,0,0,0,0,0,0
-10,11,HS Gold Standard for Depression,1006,209,70,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,12,"<3mo Visit 2-7 -n-done",1199,776,55,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-10,13,"<3mo Visit 2-7-n-More<3mo",1201,508,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,14,12,4,0,0,0,0,0,128,0,-1--1--1,,1|(1073,726)|
-1,15,13,4,0,0,0,0,0,128,0,-1--1--1,,1|(1081,589)|
-10,16,EBP Silver Standard for Depression,1129,-128,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
-10,17,HS Silver Standard for Depression,840,204,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,18,4,10,1,0,0,0,0,128,0,-1--1--1,,1|(1006,809)|
-1,19,16,9,0,0,0,0,0,128,0,-1--1--1,,1|(1212,-128)|
-10,20,"% of Total Pts <3mo w/Depression",198,696,69,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,21,"% of Total Pts <3mo w/PTSD",331,694,49,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-0-0
-10,22,"% of Total Pts <3mo w/AUD",434,688,47,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-0-0
-10,23,"% of Total Pts <3mo w/OUD",546,695,47,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-0-0
-10,24,Patients in Care More Than 3 Months,1231,895,63,27,8,130,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
-1,25,24,10,0,0,0,0,0,128,0,-1--1--1,,1|(1152,886)|
-1,26,17,16,0,0,0,0,0,128,0,-1--1--1,,1|(979,43)|
-10,27,HS Gold Standard for PTSD,1007,281,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,28,HS Silver Standard for PTSD,841,276,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,29,"# Total Pts <3mo w/2-7 Visits",869,577,59,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,30,12,29,0,0,0,0,0,128,0,-1--1--1,,1|(1039,680)|
-1,31,2,29,0,0,0,0,0,128,0,-1--1--1,,1|(1037,644)|
-1,32,13,29,0,0,0,0,0,128,0,-1--1--1,,1|(1038,541)|
-10,33,"# Pts <3mo in Team with Depression",210,621,69,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,34,"# Pts <3mo in Team w/PTSD",203,560,48,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,35,"# Pts <3mo in Team w/AUD",205,493,48,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-10,36,"# Pts <3mo in Team w/OUD",207,446,48,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,37,4,36,0,0,0,0,0,128,0,-1--1--1,,1|(591,566)|
-1,38,4,35,0,0,0,0,0,128,0,-1--1--1,,1|(590,588)|
-1,39,4,34,0,0,0,0,0,128,0,-1--1--1,,1|(589,621)|
-1,40,4,33,0,0,0,0,0,128,0,-1--1--1,,1|(603,651)|
-1,41,20,33,0,0,0,0,0,128,0,-1--1--1,,1|(202,665)|
-1,42,21,34,0,0,0,0,0,128,0,-1--1--1,,1|(271,632)|
-1,43,22,35,0,0,0,0,0,128,0,-1--1--1,,1|(324,595)|
-1,44,23,36,0,0,0,0,0,128,0,-1--1--1,,1|(382,574)|
-1,45,20,17,0,0,0,0,0,128,0,-1--1--1,,1|(512,454)|
-1,46,29,17,0,0,0,0,0,128,0,-1--1--1,,1|(855,397)|
-1,47,3,11,0,0,0,0,0,128,0,-1--1--1,,1|(1097,411)|
-1,48,20,11,0,0,0,0,0,128,0,-1--1--1,,1|(595,456)|
-1,49,29,28,0,0,0,0,0,128,0,-1--1--1,,1|(855,433)|
-1,50,21,28,0,0,0,0,0,128,0,-1--1--1,,1|(580,489)|
-1,51,20,11,0,0,0,0,0,128,0,-1--1--1,,1|(595,456)|
-1,52,21,27,0,0,0,0,0,128,0,-1--1--1,,1|(662,491)|
-1,53,3,27,0,0,0,0,0,128,0,-1--1--1,,1|(1098,447)|
-10,54,EBP Bronze Standard for PTSD,994,-60,62,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
-10,55,EBP Gold Standard for PTSD,1376,-59,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,56,EBP Silver Standard for PTSD,1184,-58,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
-1,57,56,55,0,0,0,0,0,128,0,-1--1--1,,1|(1274,-58)|
-1,58,28,56,0,0,0,0,0,128,0,-1--1--1,,1|(1006,113)|
-10,59,HS Gold Standard for AUD,1007,351,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,60,HS Silver Standard for AUD,841,346,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,61,29,60,0,0,0,0,0,64,0,-1--1--1,,1|(855,468)|
-1,62,22,60,0,0,0,0,0,64,0,-1--1--1,,1|(631,521)|
-1,63,22,59,0,0,0,0,0,64,0,-1--1--1,,1|(713,523)|
-10,64,HS Gold Standard for OUD,1010,420,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,65,HS Silver Standard for OUD,844,415,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
-1,66,29,65,0,0,0,0,0,64,0,-1--1--1,,1|(857,502)|
-1,67,23,65,0,0,0,0,0,64,0,-1--1--1,,1|(689,559)|
-1,68,23,64,0,0,0,0,0,64,0,-1--1--1,,1|(771,561)|
-10,69,EBP Bronze Standard for AUD,1058,5,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
-10,70,EBP Gold Standard for AUD,1440,7,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,71,EBP Silver Standard for AUD,1248,7,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
-1,72,71,70,0,0,0,0,0,128,0,-1--1--1,,1|(1338,7)|
-1,73,60,71,0,0,0,0,0,64,0,-1--1--1,,1|(1038,180)|
-10,74,EBP Bronze Standard for OUD,1121,69,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
-10,75,EBP Gold Standard for OUD,1503,71,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
-10,76,EBP Silver Standard for OUD,1311,71,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
-1,77,76,75,0,0,0,0,0,128,0,-1--1--1,,1|(1401,71)|
-1,78,65,76,0,0,0,0,0,64,0,-1--1--1,,1|(1071,247)|
-1,79,3,64,0,0,0,0,0,128,0,-1--1--1,,1|(1100,515)|
-1,80,3,59,0,0,0,0,0,128,0,-1--1--1,,1|(1099,481)|
-10,81,Octane Ratio,887,755,44,11,8,3,0,0,0,0,0,0
-10,82,"HS Silver Standard - All",741,822,49,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-128-128
-10,83,"HS Gold Standard - All",739,903,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-192-0
-1,84,10,81,1,0,0,0,0,128,0,-1--1--1,,1|(947,812)|
-1,85,29,82,0,0,0,0,0,64,0,-1--1--1,,1|(808,693)|
-1,86,3,83,0,0,0,0,0,128,0,-1--1--1,,1|(964,753)|
-10,87,Team Data on New Patients Starts,278,12,66,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,88,Start Rate Relative to Data,393,107,64,20,8,3,0,0,0,0,0,0
-1,89,87,88,0,0,0,0,0,128,0,-1--1--1,,1|(329,55)|
-10,90,Starting Psychotherapy,502,5,55,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,91,90,88,0,0,0,0,0,128,0,-1--1--1,,1|(452,51)|
-10,92,"HS Bronze Standard - All",754,756,46,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
-1,93,4,92,0,0,0,0,0,128,0,-1--1--1,,1|(863,711)|
-10,94,HS Bronze Standard for Depression,680,206,68,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
-10,95,HS Bronze Standard for PTSD,680,276,68,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
-10,96,HS Bronze Standard for AUD,685,341,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
-10,97,HS Bronze Standard for OUD,685,416,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
-1,98,33,94,0,0,0,0,0,128,0,-1--1--1,,1|(439,418)|
-1,99,34,95,0,0,0,0,0,128,0,-1--1--1,,1|(434,421)|
-1,100,35,96,0,0,0,0,0,128,0,-1--1--1,,1|(432,420)|
-1,101,36,97,0,0,0,0,0,128,0,-1--1--1,,1|(433,431)|
-1,102,94,8,0,0,0,0,0,128,0,-1--1--1,,1|(804,43)|
-1,103,95,54,0,0,0,0,0,128,0,-1--1--1,,1|(831,113)|
-1,104,96,69,0,0,0,0,0,128,0,-1--1--1,,1|(865,177)|
-1,105,97,74,0,0,0,0,0,128,0,-1--1--1,,1|(897,246)|
-10,106,"% of Patients who meet the HS standard who also meet the EBP standard",1117,-280,105,30,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
-1,107,106,8,0,0,0,0,0,128,0,-1--1--1,,1|(1027,-204)|
-1,108,106,54,0,0,0,0,0,64,0,-1--1--1,,1|(1056,-171)|
-1,109,106,69,0,0,0,0,0,64,0,-1--1--1,,1|(1087,-139)|
-1,110,106,74,0,0,0,0,0,64,0,-1--1--1,,1|(1118,-107)|
-1,111,106,16,0,0,0,0,0,64,0,-1--1--1,,1|(1122,-205)|
-1,112,106,56,0,0,0,0,0,64,0,-1--1--1,,1|(1149,-170)|
-1,113,106,71,0,0,0,0,0,64,0,-1--1--1,,1|(1181,-137)|
-1,114,106,76,0,0,0,0,0,64,0,-1--1--1,,1|(1212,-105)|
-1,115,106,9,0,0,0,0,0,64,0,-1--1--1,,1|(1212,-204)|
-1,116,106,55,0,0,0,0,0,64,0,-1--1--1,,1|(1246,-169)|
-1,117,106,70,0,0,0,0,0,64,0,-1--1--1,,1|(1278,-136)|
-1,118,106,75,0,0,0,0,0,64,0,-1--1--1,,1|(1309,-104)|
-10,119,"Octane Ratio - Initiators",879,821,49,20,8,3,0,0,0,0,0,0
-10,120,"Octane Ratio - Completers",890,901,49,20,8,3,0,0,0,0,0,0
-1,121,92,81,0,0,0,0,0,128,0,-1--1--1,,1|(814,755)|
-1,122,10,119,1,0,0,0,0,128,0,-1--1--1,,1|(985,853)|
-1,123,10,120,1,0,0,0,0,128,0,-1--1--1,,1|(1045,883)|
-1,124,82,119,0,0,0,0,0,128,0,-1--1--1,,1|(803,821)|
-1,125,83,120,0,0,0,0,0,128,0,-1--1--1,,1|(812,902)|
-1,126,83,119,0,0,0,0,0,64,0,-1--1--1,,1|(802,865)|
-1,127,3,65,0,0,0,0,0,128,0,-1--1--1,,1|(1016,511)|
-1,128,3,60,0,0,0,0,0,128,0,-1--1--1,,1|(1015,477)|
-1,129,3,28,0,0,0,0,0,128,0,-1--1--1,,1|(1015,443)|
-1,130,3,17,0,0,0,0,0,128,0,-1--1--1,,1|(1015,407)|
+10,1,Patients in First Visit,1133,822,77,16,8,130,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+10,2,Initiators who will Return,1101,693,65,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,3,Patients in Over 7 Visits,1094,593,68,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,4,"Total Pts <3months",858,665,35,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,5,1,4,0,0,0,0,0,128,0,-1--1--1,,1|(1005,748)|
+1,6,2,4,0,0,0,0,0,128,0,-1--1--1,,1|(971,678)|
+1,7,3,4,0,0,0,0,0,128,0,-1--1--1,,1|(966,631)|
+10,8,EBP Bronze Standard for Depression,847,-143,72,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
+10,9,EBP Gold Standard for Depression,1215,-142,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,10,Total Pts in Psych,974,865,57,11,8,3,0,0,0,0,0,0
+10,11,HS Gold Standard for Depression,914,196,70,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,12,Initiators who will Quit,1107,763,55,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+10,13,Initiators who will Continue,1109,495,65,20,8,2,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,14,12,4,0,0,0,0,0,128,0,-1--1--1,,1|(981,713)|
+1,15,13,4,0,0,0,0,0,128,0,-1--1--1,,1|(989,576)|
+10,16,EBP Silver Standard for Depression,1037,-141,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
+10,17,HS Silver Standard for Depression,748,191,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,18,4,10,1,0,0,0,0,128,0,-1--1--1,,1|(914,796)|
+1,19,16,9,0,0,0,0,0,128,0,-1--1--1,,1|(1120,-142)|
+10,20,"DEP within 3 months %",106,683,43,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,21,"PTSD within 3 months %",239,681,47,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,22,"AUD within 3 months %",342,675,44,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,23,"OUD within 3 months %",454,682,44,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,24,Patients in Care More Than 3 Months,1139,882,63,27,8,130,0,43,-1,0,0,0,128-128-128,0-0-0,Meiryo|10||128-128-128
+1,25,24,10,0,0,0,0,0,128,0,-1--1--1,,1|(1060,873)|
+1,26,17,16,0,0,0,0,0,128,0,-1--1--1,,1|(887,30)|
+10,27,HS Gold Standard for PTSD,915,268,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,28,HS Silver Standard for PTSD,749,263,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,29,Total Initiators,777,564,48,11,8,3,0,0,0,0,0,0
+1,30,12,29,0,0,0,0,0,128,0,-1--1--1,,1|(940,662)|
+1,31,2,29,0,0,0,0,0,128,0,-1--1--1,,1|(934,626)|
+1,32,13,29,0,0,0,0,0,128,0,-1--1--1,,1|(941,529)|
+10,33,"# Pts <3mo in Team with Depression",118,608,69,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,34,"# Pts <3mo in Team w/PTSD",111,547,48,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,35,"# Pts <3mo in Team w/AUD",113,480,48,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+10,36,"# Pts <3mo in Team w/OUD",115,433,48,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,37,4,36,0,0,0,0,0,128,0,-1--1--1,,1|(499,553)|
+1,38,4,35,0,0,0,0,0,128,0,-1--1--1,,1|(498,575)|
+1,39,4,34,0,0,0,0,0,128,0,-1--1--1,,1|(497,608)|
+1,40,4,33,0,0,0,0,0,128,0,-1--1--1,,1|(511,638)|
+1,41,20,33,0,0,0,0,0,128,0,-1--1--1,,1|(110,652)|
+1,42,21,34,0,0,0,0,0,128,0,-1--1--1,,1|(179,619)|
+1,43,22,35,0,0,0,0,0,128,0,-1--1--1,,1|(232,582)|
+1,44,23,36,0,0,0,0,0,128,0,-1--1--1,,1|(290,561)|
+1,45,20,17,0,0,0,0,0,128,0,-1--1--1,,1|(420,441)|
+1,46,29,17,0,0,0,0,0,128,0,-1--1--1,,1|(763,388)|
+1,47,3,11,0,0,0,0,0,128,0,-1--1--1,,1|(1005,398)|
+1,48,20,11,0,0,0,0,0,128,0,-1--1--1,,1|(503,443)|
+1,49,29,28,0,0,0,0,0,128,0,-1--1--1,,1|(763,424)|
+1,50,21,28,0,0,0,0,0,128,0,-1--1--1,,1|(488,476)|
+1,51,20,11,0,0,0,0,0,128,0,-1--1--1,,1|(503,443)|
+1,52,21,27,0,0,0,0,0,128,0,-1--1--1,,1|(570,478)|
+1,53,3,27,0,0,0,0,0,128,0,-1--1--1,,1|(1006,434)|
+10,54,EBP Bronze Standard for PTSD,902,-73,62,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
+10,55,EBP Gold Standard for PTSD,1284,-72,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,56,EBP Silver Standard for PTSD,1092,-71,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
+1,57,56,55,0,0,0,0,0,128,0,-1--1--1,,1|(1182,-72)|
+1,58,28,56,0,0,0,0,0,128,0,-1--1--1,,1|(914,100)|
+10,59,HS Gold Standard for AUD,915,338,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,60,HS Silver Standard for AUD,749,333,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,61,29,60,0,0,0,0,0,64,0,-1--1--1,,1|(764,459)|
+1,62,22,60,0,0,0,0,0,64,0,-1--1--1,,1|(539,508)|
+1,63,22,59,0,0,0,0,0,64,0,-1--1--1,,1|(621,510)|
+10,64,HS Gold Standard for OUD,918,407,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,65,HS Silver Standard for OUD,752,402,62,20,8,3,0,40,0,0,0,0,0-0-0,0-0-0,Meiryo|10||0-0-0
+1,66,29,65,0,0,0,0,0,64,0,-1--1--1,,1|(766,494)|
+1,67,23,65,0,0,0,0,0,64,0,-1--1--1,,1|(597,546)|
+1,68,23,64,0,0,0,0,0,64,0,-1--1--1,,1|(679,548)|
+10,69,EBP Bronze Standard for AUD,966,-8,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
+10,70,EBP Gold Standard for AUD,1348,-6,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,71,EBP Silver Standard for AUD,1156,-6,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
+1,72,71,70,0,0,0,0,0,128,0,-1--1--1,,1|(1246,-6)|
+1,73,60,71,0,0,0,0,0,64,0,-1--1--1,,1|(946,167)|
+10,74,EBP Bronze Standard for OUD,1029,56,59,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||128-64-0
+10,75,EBP Gold Standard for OUD,1411,58,63,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||255-192-0
+10,76,EBP Silver Standard for OUD,1219,58,66,20,8,3,0,42,0,0,0,0,-1--1--1,0-0-0,Meiryo|10||160-160-160
+1,77,76,75,0,0,0,0,0,128,0,-1--1--1,,1|(1309,58)|
+1,78,65,76,0,0,0,0,0,64,0,-1--1--1,,1|(979,234)|
+1,79,3,64,0,0,0,0,0,128,0,-1--1--1,,1|(1008,502)|
+1,80,3,59,0,0,0,0,0,128,0,-1--1--1,,1|(1007,468)|
+10,81,Octane Ratio,795,742,44,11,8,3,0,0,0,0,0,0
+10,82,"HS Silver Standard - All",649,809,49,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-128-128
+10,83,"HS Gold Standard - All",647,890,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-192-0
+1,84,10,81,1,0,0,0,0,128,0,-1--1--1,,1|(855,799)|
+1,85,29,82,0,0,0,0,0,64,0,-1--1--1,,1|(718,675)|
+1,86,3,83,0,0,0,0,0,128,0,-1--1--1,,1|(872,740)|
+10,87,Team Data on New Patients Starts,186,-1,66,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,88,Start Rate Relative to Data,301,94,64,20,8,3,0,0,0,0,0,0
+1,89,87,88,0,0,0,0,0,128,0,-1--1--1,,1|(237,42)|
+10,90,Starting Psychotherapy,410,-8,55,20,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,91,90,88,0,0,0,0,0,128,0,-1--1--1,,1|(360,38)|
+10,92,"HS Bronze Standard - All",662,743,46,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
+1,93,4,92,0,0,0,0,0,128,0,-1--1--1,,1|(771,698)|
+10,94,HS Bronze Standard for Depression,588,193,68,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
+10,95,HS Bronze Standard for PTSD,588,263,68,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
+10,96,HS Bronze Standard for AUD,593,328,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
+10,97,HS Bronze Standard for OUD,593,403,59,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-64-0
+1,98,33,94,0,0,0,0,0,128,0,-1--1--1,,1|(347,405)|
+1,99,34,95,0,0,0,0,0,128,0,-1--1--1,,1|(342,408)|
+1,100,35,96,0,0,0,0,0,128,0,-1--1--1,,1|(340,407)|
+1,101,36,97,0,0,0,0,0,128,0,-1--1--1,,1|(341,418)|
+1,102,94,8,0,0,0,0,0,128,0,-1--1--1,,1|(712,30)|
+1,103,95,54,0,0,0,0,0,128,0,-1--1--1,,1|(739,100)|
+1,104,96,69,0,0,0,0,0,128,0,-1--1--1,,1|(773,164)|
+1,105,97,74,0,0,0,0,0,128,0,-1--1--1,,1|(805,233)|
+10,106,"Patients with Adequate EBP Templates %",1025,-293,78,20,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-255
+1,107,106,8,0,0,0,0,0,128,0,-1--1--1,,1|(941,-222)|
+1,108,106,54,0,0,0,0,0,64,0,-1--1--1,,1|(966,-189)|
+1,109,106,69,0,0,0,0,0,64,0,-1--1--1,,1|(996,-157)|
+1,110,106,74,0,0,0,0,0,64,0,-1--1--1,,1|(1026,-126)|
+1,111,106,16,0,0,0,0,0,64,0,-1--1--1,,1|(1029,-223)|
+1,112,106,56,0,0,0,0,0,64,0,-1--1--1,,1|(1056,-188)|
+1,113,106,71,0,0,0,0,0,64,0,-1--1--1,,1|(1087,-155)|
+1,114,106,76,0,0,0,0,0,64,0,-1--1--1,,1|(1118,-124)|
+1,115,106,9,0,0,0,0,0,64,0,-1--1--1,,1|(1114,-221)|
+1,116,106,55,0,0,0,0,0,64,0,-1--1--1,,1|(1148,-187)|
+1,117,106,70,0,0,0,0,0,64,0,-1--1--1,,1|(1180,-154)|
+1,118,106,75,0,0,0,0,0,64,0,-1--1--1,,1|(1212,-123)|
+10,119,"Octane Ratio - Initiators",787,808,49,20,8,3,0,0,0,0,0,0
+10,120,"Octane Ratio - Completers",798,888,49,20,8,3,0,0,0,0,0,0
+1,121,92,81,0,0,0,0,0,128,0,-1--1--1,,1|(722,742)|
+1,122,10,119,1,0,0,0,0,128,0,-1--1--1,,1|(893,840)|
+1,123,10,120,1,0,0,0,0,128,0,-1--1--1,,1|(953,870)|
+1,124,82,119,0,0,0,0,0,128,0,-1--1--1,,1|(711,808)|
+1,125,83,120,0,0,0,0,0,128,0,-1--1--1,,1|(720,889)|
+1,126,83,119,0,0,0,0,0,64,0,-1--1--1,,1|(710,852)|
+1,127,3,65,0,0,0,0,0,128,0,-1--1--1,,1|(924,498)|
+1,128,3,60,0,0,0,0,0,128,0,-1--1--1,,1|(923,464)|
+1,129,3,28,0,0,0,0,0,128,0,-1--1--1,,1|(923,430)|
+1,130,3,17,0,0,0,0,0,128,0,-1--1--1,,1|(923,394)|
 \\\---/// Sketch information - do not modify anything except names
 V300  Do not put anything below this section - it will be ignored
 *UI Outputs
-$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,80,0
-10,1,SankeyScalar,602,465,35,17,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
-10,2,A,486,395,8,11,8,3,0,0,0,0,0,0
-1,3,1,2,0,0,0,0,0,64,0,-1--1--1,,1|(539,427)|
-10,4,B,491,424,7,11,8,3,0,0,0,0,0,0
-1,5,1,4,0,0,0,0,0,64,0,-1--1--1,,1|(539,442)|
-10,6,C,499,454,8,11,8,3,0,0,0,0,0,0
-1,7,1,6,0,0,0,0,0,64,0,-1--1--1,,1|(543,458)|
-10,8,D,500,475,8,11,8,3,0,0,0,0,0,0
-1,9,1,8,0,0,0,0,0,64,0,-1--1--1,,1|(544,470)|
-10,10,E,508,497,7,11,8,3,0,0,0,0,0,0
-1,11,1,10,0,0,0,0,0,64,0,-1--1--1,,1|(547,482)|
-10,12,F,513,516,7,11,8,3,0,0,0,0,0,0
-1,13,1,12,0,0,0,0,0,64,0,-1--1--1,,1|(552,493)|
-10,14,G,521,538,8,11,8,3,0,0,0,0,0,0
-1,15,1,14,0,0,0,0,0,64,0,-1--1--1,,1|(561,501)|
-10,16,H,536,558,8,11,8,3,0,0,0,0,0,0
-1,17,1,16,0,0,0,0,0,64,0,-1--1--1,,1|(570,508)|
-10,18,"Exp-A",753,376,23,11,8,3,0,0,0,0,0,0
-10,19,"Exp-B",767,404,22,11,8,3,0,0,0,0,0,0
-10,20,"Exp-C",792,429,23,11,8,3,0,0,0,0,0,0
-10,21,"Exp-D",816,453,23,11,8,3,0,0,0,0,0,0
-10,22,"Exp-E",840,476,22,11,8,3,0,0,0,0,0,0
-10,23,"Exp-F",862,500,22,11,8,3,0,0,0,0,0,0
-10,24,"Exp-G",883,524,23,11,8,3,0,0,0,0,0,0
-10,25,"Exp-H",908,548,23,11,8,3,0,0,0,0,0,0
-10,26,FINAL TIME,1015,485,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,27,26,21,0,0,0,0,0,64,0,-1--1--1,,1|(906,467)|
-10,28,Time,1003,504,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,29,28,21,0,0,0,0,0,64,0,-1--1--1,,1|(914,479)|
-10,30,FINAL TIME,1044,542,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,31,30,22,0,0,0,0,0,64,0,-1--1--1,,1|(942,509)|
-10,32,Time,1019,523,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,33,32,22,0,0,0,0,0,64,0,-1--1--1,,1|(934,500)|
-10,34,FINAL TIME,1090,587,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,35,34,23,0,0,0,0,0,64,0,-1--1--1,,1|(979,544)|
-10,36,Time,1071,566,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,37,36,23,0,0,0,0,0,64,0,-1--1--1,,1|(971,534)|
-10,38,FINAL TIME,1114,630,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,39,38,24,0,0,0,0,0,64,0,-1--1--1,,1|(1004,579)|
-10,40,Time,1095,607,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,41,40,24,0,0,0,0,0,64,0,-1--1--1,,1|(994,567)|
-10,42,FINAL TIME,1120,679,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,43,42,25,0,0,0,0,0,64,0,-1--1--1,,1|(1019,617)|
-10,44,Time,1116,655,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
-1,45,44,25,0,0,0,0,0,64,0,-1--1--1,,1|(1018,604)|
-10,46,FINAL TIME,820,347,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,47,46,18,0,0,0,0,0,64,0,-1--1--1,,1|(791,359)|
-10,48,Time,806,364,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,49,48,18,0,0,0,0,0,64,0,-1--1--1,,1|(784,367)|
-10,50,FINAL TIME,867,393,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,51,50,19,0,0,0,0,0,64,0,-1--1--1,,1|(807,399)|
-10,52,Time,876,414,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,53,52,19,0,0,0,0,0,64,0,-1--1--1,,1|(826,409)|
-10,54,FINAL TIME,959,461,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,55,54,20,0,0,0,0,0,64,0,-1--1--1,,1|(866,443)|
-10,56,Time,947,442,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,57,56,20,0,0,0,0,0,64,0,-1--1--1,,1|(874,435)|
-10,58,"% Go on to 2-7 in <3mo Data",402,358,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,59,58,2,0,0,0,0,0,64,0,-1--1--1,,1|(455,381)|
-10,60,"% Go on to 2-7 in <3mo Data",266,403,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,61,60,4,0,0,0,0,0,64,0,-1--1--1,,1|(400,414)|
-10,62,"%Visit1<3mo and More Data",390,407,63,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,63,62,4,0,0,0,0,0,64,0,-1--1--1,,1|(461,418)|
-10,64,"%Visit1<3mo and More Data",398,452,63,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,65,64,6,0,0,0,0,0,64,0,-1--1--1,,1|(469,453)|
-10,66,"% Go on to 2-7 in <3mo Data",257,487,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,67,66,8,0,0,0,0,0,64,0,-1--1--1,,1|(399,479)|
-10,68,"%Visit2-7-n-Done Data",390,491,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,69,68,8,0,0,0,0,0,64,0,-1--1--1,,1|(466,480)|
-10,70,"% Go on to 2-7 in <3mo Data",101,523,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,71,70,10,0,0,0,0,0,64,0,-1--1--1,,1|(326,508)|
-10,72,"%Visit2-7-n-Done Data",232,526,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,73,72,10,0,0,0,0,0,64,0,-1--1--1,,1|(392,509)|
-10,74,"%Visit2-7-n-More<3mo Data",382,523,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,75,74,10,0,0,0,0,0,64,0,-1--1--1,,1|(476,503)|
-10,76,"% Go on to 2-7 in <3mo Data",217,571,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,77,76,12,0,0,0,0,0,64,0,-1--1--1,,1|(386,539)|
-10,78,"%Visit2-7-n-More<3mo Data",366,566,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,79,78,12,0,0,0,0,0,64,0,-1--1--1,,1|(456,534)|
-10,80,"% Go on to 2-7 in <3mo Data",138,646,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,81,80,14,0,0,0,0,0,64,0,-1--1--1,,1|(350,585)|
-10,82,"%Visit2-7-n-More<3mo Data",291,635,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,83,82,14,0,0,0,0,0,64,0,-1--1--1,,1|(418,581)|
-10,84,"%Visit8PL-n-Done Data",417,606,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,85,84,14,0,0,0,0,0,64,0,-1--1--1,,1|(473,568)|
-10,86,"% Go on to 2-7 in <3mo Data",529,622,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,87,86,16,0,0,0,0,0,64,0,-1--1--1,,1|(531,592)|
-10,88,"%Visit2-7-n-More<3mo Data",434,664,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,89,88,16,0,0,0,0,0,64,0,-1--1--1,,1|(485,610)|
-10,90,"%Visit8PL-n-Done Data",262,690,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,91,90,16,0,0,0,0,0,64,0,-1--1--1,,1|(408,619)|
-10,92,"C-Bars",639,779,25,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-0-128
-10,93,"D-Bars",744,778,25,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,94,"Bars E4-Initial",638,809,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,95,94,92,0,0,0,0,0,64,0,-1--1--1,,1|(638,801)|
-10,96,Sankey E5,640,853,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-10,97,Sankey E2,936,353,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,98,97,18,0,0,0,0,0,64,0,-1--1--1,,1|(840,364)|
-10,99,Sankey E3,994,402,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,100,99,19,0,0,0,0,0,64,0,-1--1--1,,1|(876,402)|
-10,101,Sankey E4,1050,432,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,102,101,20,0,0,0,0,0,64,0,-1--1--1,,1|(917,430)|
-10,103,Sankey E2,1219,457,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,104,103,21,0,0,0,0,0,64,0,-1--1--1,,1|(1013,455)|
-10,105,Sankey E5,1121,461,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,106,105,21,0,0,0,0,0,64,0,-1--1--1,,1|(964,456)|
-10,107,Sankey E2,1264,492,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,108,107,22,0,0,0,0,0,64,0,-1--1--1,,1|(1047,483)|
-10,109,Sankey E6,1154,493,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,110,109,22,0,0,0,0,0,64,0,-1--1--1,,1|(992,484)|
-10,111,Sankey E2,1283,530,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,112,111,23,0,0,0,0,0,64,0,-1--1--1,,1|(1068,514)|
-10,113,Sankey E7,1168,529,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,114,113,23,0,0,0,0,0,64,0,-1--1--1,,1|(1010,514)|
-10,115,Sankey E2,1400,562,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,116,115,24,0,0,0,0,0,64,0,-1--1--1,,1|(1137,542)|
-10,117,Sankey E7,1298,562,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,118,117,24,0,0,0,0,0,64,0,-1--1--1,,1|(1086,542)|
-10,119,Sankey E8,1194,562,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,120,119,24,0,0,0,0,0,64,0,-1--1--1,,1|(1034,542)|
-10,121,Sankey E2,1407,600,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,122,121,25,0,0,0,0,0,64,0,-1--1--1,,1|(1153,573)|
-10,123,Sankey E7,1317,598,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,124,123,25,0,0,0,0,0,64,0,-1--1--1,,1|(1108,572)|
-10,125,Sankey E9,1224,597,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,126,125,25,0,0,0,0,0,64,0,-1--1--1,,1|(1062,572)|
-10,127,Bars E5,744,808,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,128,127,93,0,0,0,0,0,64,0,-1--1--1,,1|(744,800)|
-10,129,"E-Bars",844,778,24,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,130,Bars E6,844,808,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,131,130,129,0,0,0,0,0,64,0,-1--1--1,,1|(844,800)|
-10,132,"Bars E6 >3mo-Initial",840,844,44,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,133,132,129,0,0,0,0,0,64,0,-1--1--1,,1|(841,813)|
-10,134,"H-Bars",1043,777,29,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,135,Bars E7,1043,807,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,136,135,134,0,0,0,0,0,64,0,-1--1--1,,1|(1043,799)|
-10,137,Bars E8,1043,836,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,138,137,134,0,0,0,0,0,64,0,-1--1--1,,1|(1043,813)|
-10,139,"Bars E9-Initial",1043,868,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,140,139,134,0,0,0,0,0,64,0,-1--1--1,,1|(1043,829)|
-10,141,"G-Bars",945,778,30,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,142,Bars E7,945,808,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,143,142,141,0,0,0,0,0,64,0,-1--1--1,,1|(945,800)|
-10,144,Bars E8,945,839,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,145,144,141,0,0,0,0,0,64,0,-1--1--1,,1|(945,815)|
-10,146,"Exp-C-Bars",640,923,40,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,147,"Exp-E-Bars",845,922,39,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,148,"Exp-H-Bars",1044,921,40,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
-10,149,"Bars E4-Final",640,953,53,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,150,149,146,0,0,0,0,0,64,0,-1--1--1,,1|(640,945)|
-10,151,Bars E6,845,952,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,152,151,147,0,0,0,0,0,64,0,-1--1--1,,1|(845,944)|
-10,153,"Bars E6 >3mo-Final",845,1000,43,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,154,153,147,0,0,0,0,0,64,0,-1--1--1,,1|(845,964)|
-10,155,Bars E7,1044,951,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,156,155,148,0,0,0,0,0,64,0,-1--1--1,,1|(1044,943)|
-10,157,Bars E8,1046,978,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,158,157,148,0,0,0,0,0,64,0,-1--1--1,,1|(1045,956)|
-10,159,"Bars E9-Final",1045,1016,53,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,160,159,148,0,0,0,0,0,64,0,-1--1--1,,1|(1044,975)|
-10,161,Total Pts in Psych,939,176,41,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-10,162,Total Pts at Final Time,767,257,54,19,8,3,0,0,0,0,0,0
-1,163,161,162,0,0,0,0,0,128,0,-1--1--1,,1|(859,213)|
-10,164,FINAL TIME,946,227,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,165,164,162,0,0,0,0,0,64,0,-1--1--1,,1|(862,240)|
-10,166,Time,849,177,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,167,166,162,0,0,0,0,0,64,0,-1--1--1,,1|(817,208)|
-10,168,Percent Change in Total Patients,643,193,58,19,8,3,0,0,0,0,0,0
-1,169,162,168,0,0,0,0,0,128,0,-1--1--1,,1|(711,228)|
-10,170,"Exp-SankeyScalar",706,470,59,11,8,131,0,0,0,0,0,0
-1,171,1,170,0,0,0,0,0,128,0,-1--1--1,,1|(635,465)|
-1,172,168,170,0,0,0,0,0,128,0,-1--1--1,,1|(673,328)|
-10,173,FINAL TIME,571,338,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,174,173,170,0,0,0,0,0,64,0,-1--1--1,,1|(633,399)|
-10,175,Time,645,370,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
-1,176,175,170,0,0,0,0,0,64,0,-1--1--1,,1|(671,414)|
-10,177,Total Pts at Initial Time,774,109,56,19,8,3,0,0,0,0,0,0
-1,178,177,168,0,0,0,0,0,128,0,-1--1--1,,1|(714,147)|
-1,179,161,177,0,0,0,0,0,128,0,-1--1--1,,1|(865,146)|
-1,180,166,177,0,0,0,0,0,128,0,-1--1--1,,1|(820,151)|
-1,181,166,168,0,0,0,0,0,128,0,-1--1--1,,1|(768,182)|
-1,182,173,168,0,0,0,0,0,128,0,-1--1--1,,1|(601,275)|
-1,183,170,18,0,0,0,0,0,128,0,-1--1--1,,1|(725,429)|
-1,184,170,19,0,0,0,0,0,64,0,-1--1--1,,1|(731,442)|
-1,185,170,20,0,0,0,0,0,64,0,-1--1--1,,1|(742,452)|
-1,186,170,21,0,0,0,0,0,64,0,-1--1--1,,1|(772,459)|
-1,187,170,22,0,0,0,0,0,64,0,-1--1--1,,1|(784,473)|
-1,188,170,23,0,0,0,0,0,64,0,-1--1--1,,1|(794,486)|
-1,189,170,24,0,0,0,0,0,64,0,-1--1--1,,1|(794,496)|
-1,190,170,25,0,0,0,0,0,64,0,-1--1--1,,1|(802,507)|
-///---\\\
-:GRAPH BehaviorOverTime
-:TITLE BehaviorOverTime
-:X-MIN -13
-:SCALE
-:VAR Total Supply
-:VAR Supply Used by All Pts
-:VAR Supply Available for New Pts
-:VAR Starting Psychotherapy
-:SCALE
-:VAR Graduation Rate
-
-:GRAPH Supply_Used
-:TITLE Supply Used
-:X-AXIS Time
-:X-MIN -13
-:STACK-FILL 6
-:SCALE
-:VAR "<3mo - Supply Used by Visit1"
-:Y-MIN 0
-:VAR "<3mo - Supply Used by Visit 2-7"
-:Y-MIN 0
-:VAR "<3mo - Supply Used by Visit 8PL"
-:Y-MIN 0
-:VAR ">3mo - Supply Used by FromVisit1"
-:Y-MIN 0
-:VAR ">3mo - Supply Used by FromVisit2-7"
-:Y-MIN 0
-:VAR ">3mo - Supply Used by FromVisit8PL"
-:Y-MIN 0
-
-:GRAPH Performance_Measures_Overview
-:TITLE Performance Measures Overview
-:X-MIN -13
-:SCALE
-:VAR "HS Pts<=3mo over Total - All"
-:VAR "HS Silver Standard - All"
-:VAR "HS Gold Standard - All"
-
-:GRAPH Depression
-:TITLE % of Depression Pts Meeting Standard
-:X-MIN 0
-:SCALE
-:VAR EBP Bronze Standard for Depression
-:VAR EBP Silver Standard for Depression
-:VAR EBP Gold Standard for Depression
-:VAR HS Bronze Standard for Depression
-:VAR HS Silver Standard for Depression
-:VAR HS Gold Standard for Depression
-
-:GRAPH PTSD
-:TITLE % of PTSD Pts Meeting Standard
-:X-MIN 0
-:SCALE
-:VAR EBP Bronze Standard for PTSD
-:VAR EBP Silver Standard for PTSD
-:VAR EBP Gold Standard for PTSD
-:VAR HS Bronze Standard for PTSD
-:VAR HS Silver Standard for PTSD
-:VAR HS Gold Standard for PTSD
-
-:GRAPH AUD
-:TITLE % of AUD Pts Meeting Standard
-:X-MIN 0
-:SCALE
-:VAR EBP Bronze Standard for AUD
-:VAR EBP Silver Standard for AUD
-:VAR EBP Gold Standard for AUD
-:VAR HS Bronze Standard for AUD
-:VAR HS Silver Standard for AUD
-:VAR HS Gold Standard for AUD
-
-:GRAPH OUD
-:TITLE % of OUD Pts Meeting Standard
-:X-MIN 0
-:SCALE
-:VAR EBP Bronze Standard for OUD
-:VAR EBP Silver Standard for OUD
-:VAR EBP Gold Standard for OUD
-:VAR HS Bronze Standard for OUD
-:VAR HS Silver Standard for OUD
-:VAR HS Gold Standard for OUD
-:L<%^E!@
-1:PSY--June21-monkeywrench.vdf
-1:PSY--June21-realdata.vdf
-9:PSY--June21-monkeywrench
-22:$,Dollar,Dollars,$s
-22:Hour,Hours
-22:Month,Months
-22:Person,People,Persons
-22:Unit,Units
-22:Week,Weeks
-22:Year,Years
-22:Day,Days
-23:0
-15:0,0,0,0,0,0
-19:70,2
-27:2,
-34:0,
-4:Time
-5:"Percent Change RVI of Patients in Care >3mo"
-35:Date
-36:YYYY-MM-DD
-37:2000
-38:1
-39:1
-40:3
-41:0
-42:1
-24:-500
-25:104
-26:104
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,70,0
+10,1,SankeyScalar,660,484,35,17,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|10||255-0-0
+10,2,A,544,414,8,11,8,3,0,0,0,0,0,0
+1,3,1,2,0,0,0,0,0,64,0,-1--1--1,,1|(597,446)|
+10,4,B,549,443,7,11,8,3,0,0,0,0,0,0
+1,5,1,4,0,0,0,0,0,64,0,-1--1--1,,1|(597,461)|
+10,6,C,557,473,8,11,8,3,0,0,0,0,0,0
+1,7,1,6,0,0,0,0,0,64,0,-1--1--1,,1|(601,477)|
+10,8,D,558,494,8,11,8,3,0,0,0,0,0,0
+1,9,1,8,0,0,0,0,0,64,0,-1--1--1,,1|(602,489)|
+10,10,E,566,516,7,11,8,3,0,0,0,0,0,0
+1,11,1,10,0,0,0,0,0,64,0,-1--1--1,,1|(605,501)|
+10,12,F,571,535,7,11,8,3,0,0,0,0,0,0
+1,13,1,12,0,0,0,0,0,64,0,-1--1--1,,1|(610,512)|
+10,14,G,579,557,8,11,8,3,0,0,0,0,0,0
+1,15,1,14,0,0,0,0,0,64,0,-1--1--1,,1|(619,520)|
+10,16,H,594,577,8,11,8,3,0,0,0,0,0,0
+1,17,1,16,0,0,0,0,0,64,0,-1--1--1,,1|(628,527)|
+10,18,"Exp-A",811,395,23,11,8,3,0,0,0,0,0,0
+10,19,"Exp-B",825,423,22,11,8,3,0,0,0,0,0,0
+10,20,"Exp-C",850,448,23,11,8,3,0,0,0,0,0,0
+10,21,"Exp-D",874,472,23,11,8,3,0,0,0,0,0,0
+10,22,"Exp-E",898,495,22,11,8,3,0,0,0,0,0,0
+10,23,"Exp-F",920,519,22,11,8,3,0,0,0,0,0,0
+10,24,"Exp-G",941,543,23,11,8,3,0,0,0,0,0,0
+10,25,"Exp-H",966,567,23,11,8,3,0,0,0,0,0,0
+10,26,FINAL TIME,1073,504,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,27,26,21,0,0,0,0,0,64,0,-1--1--1,,1|(964,486)|
+10,28,Time,1061,523,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,29,28,21,0,0,0,0,0,64,0,-1--1--1,,1|(972,498)|
+10,30,FINAL TIME,1102,561,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,31,30,22,0,0,0,0,0,64,0,-1--1--1,,1|(1000,528)|
+10,32,Time,1077,542,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,33,32,22,0,0,0,0,0,64,0,-1--1--1,,1|(992,519)|
+10,34,FINAL TIME,1148,606,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,35,34,23,0,0,0,0,0,64,0,-1--1--1,,1|(1037,563)|
+10,36,Time,1129,585,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,37,36,23,0,0,0,0,0,64,0,-1--1--1,,1|(1029,553)|
+10,38,FINAL TIME,1172,649,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,39,38,24,0,0,0,0,0,64,0,-1--1--1,,1|(1062,598)|
+10,40,Time,1153,626,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,41,40,24,0,0,0,0,0,64,0,-1--1--1,,1|(1052,586)|
+10,42,FINAL TIME,1178,698,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,43,42,25,0,0,0,0,0,64,0,-1--1--1,,1|(1077,636)|
+10,44,Time,1174,674,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|10||128-128-128
+1,45,44,25,0,0,0,0,0,64,0,-1--1--1,,1|(1076,623)|
+10,46,FINAL TIME,878,366,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,47,46,18,0,0,0,0,0,64,0,-1--1--1,,1|(849,378)|
+10,48,Time,864,383,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,49,48,18,0,0,0,0,0,64,0,-1--1--1,,1|(842,386)|
+10,50,FINAL TIME,925,412,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,51,50,19,0,0,0,0,0,64,0,-1--1--1,,1|(865,418)|
+10,52,Time,934,433,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,53,52,19,0,0,0,0,0,64,0,-1--1--1,,1|(884,428)|
+10,54,FINAL TIME,1017,480,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,55,54,20,0,0,0,0,0,64,0,-1--1--1,,1|(924,462)|
+10,56,Time,1005,461,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,57,56,20,0,0,0,0,0,64,0,-1--1--1,,1|(932,454)|
+10,58,"Starters Who Initiate %",460,377,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,59,58,2,0,0,0,0,0,64,0,-1--1--1,,1|(513,400)|
+10,60,"Starters Who Initiate %",324,422,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,61,60,4,0,0,0,0,0,64,0,-1--1--1,,1|(458,433)|
+10,62,"Starters Who Return Later %",448,426,63,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,63,62,4,0,0,0,0,0,64,0,-1--1--1,,1|(519,437)|
+10,64,"Starters Who Return Later %",456,471,63,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,65,64,6,0,0,0,0,0,64,0,-1--1--1,,1|(527,472)|
+10,66,"Starters Who Initiate %",315,506,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,67,66,8,0,0,0,0,0,64,0,-1--1--1,,1|(457,498)|
+10,68,"Initiators Who Quit Early %",448,510,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,69,68,8,0,0,0,0,0,64,0,-1--1--1,,1|(524,499)|
+10,70,"Starters Who Initiate %",159,542,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,71,70,10,0,0,0,0,0,64,0,-1--1--1,,1|(384,527)|
+10,72,"Initiators Who Quit Early %",290,545,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,73,72,10,0,0,0,0,0,64,0,-1--1--1,,1|(450,528)|
+10,74,"Initiators Who Complete %",440,542,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,75,74,10,0,0,0,0,0,64,0,-1--1--1,,1|(534,522)|
+10,76,"Starters Who Initiate %",275,590,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,77,76,12,0,0,0,0,0,64,0,-1--1--1,,1|(444,558)|
+10,78,"Initiators Who Complete %",424,585,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,79,78,12,0,0,0,0,0,64,0,-1--1--1,,1|(514,553)|
+10,80,"Starters Who Initiate %",196,665,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,81,80,14,0,0,0,0,0,64,0,-1--1--1,,1|(408,604)|
+10,82,"Initiators Who Complete %",349,654,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,83,82,14,0,0,0,0,0,64,0,-1--1--1,,1|(476,600)|
+10,84,"Completers Who Graduate %",475,625,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,85,84,14,0,0,0,0,0,64,0,-1--1--1,,1|(531,587)|
+10,86,"Starters Who Initiate %",587,641,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,87,86,16,0,0,0,0,0,64,0,-1--1--1,,1|(589,611)|
+10,88,"Initiators Who Complete %",492,683,84,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,89,88,16,0,0,0,0,0,64,0,-1--1--1,,1|(543,629)|
+10,90,"Completers Who Graduate %",320,709,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,91,90,16,0,0,0,0,0,64,0,-1--1--1,,1|(466,638)|
+10,92,"C-Bars",697,798,25,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|10||128-0-128
+10,93,"D-Bars",802,797,25,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,94,"Bars E4-Initial",696,828,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,95,94,92,0,0,0,0,0,64,0,-1--1--1,,1|(696,820)|
+10,96,Sankey E5,698,872,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+10,97,Sankey E2,994,372,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,98,97,18,0,0,0,0,0,64,0,-1--1--1,,1|(898,383)|
+10,99,Sankey E3,1052,421,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,100,99,19,0,0,0,0,0,64,0,-1--1--1,,1|(934,421)|
+10,101,Sankey E4,1108,451,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,102,101,20,0,0,0,0,0,64,0,-1--1--1,,1|(975,449)|
+10,103,Sankey E2,1277,476,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,104,103,21,0,0,0,0,0,64,0,-1--1--1,,1|(1071,474)|
+10,105,Sankey E5,1179,480,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,106,105,21,0,0,0,0,0,64,0,-1--1--1,,1|(1022,475)|
+10,107,Sankey E2,1322,511,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,108,107,22,0,0,0,0,0,64,0,-1--1--1,,1|(1105,502)|
+10,109,Sankey E6,1212,512,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,110,109,22,0,0,0,0,0,64,0,-1--1--1,,1|(1050,503)|
+10,111,Sankey E2,1341,549,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,112,111,23,0,0,0,0,0,64,0,-1--1--1,,1|(1126,533)|
+10,113,Sankey E7,1226,548,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,114,113,23,0,0,0,0,0,64,0,-1--1--1,,1|(1068,533)|
+10,115,Sankey E2,1458,581,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,116,115,24,0,0,0,0,0,64,0,-1--1--1,,1|(1195,561)|
+10,117,Sankey E7,1356,581,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,118,117,24,0,0,0,0,0,64,0,-1--1--1,,1|(1144,561)|
+10,119,Sankey E8,1252,581,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,120,119,24,0,0,0,0,0,64,0,-1--1--1,,1|(1092,561)|
+10,121,Sankey E2,1465,619,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,122,121,25,0,0,0,0,0,64,0,-1--1--1,,1|(1211,592)|
+10,123,Sankey E7,1375,617,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,124,123,25,0,0,0,0,0,64,0,-1--1--1,,1|(1166,591)|
+10,125,Sankey E9,1282,616,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,126,125,25,0,0,0,0,0,64,0,-1--1--1,,1|(1120,591)|
+10,127,Bars E5,802,827,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,128,127,93,0,0,0,0,0,64,0,-1--1--1,,1|(802,819)|
+10,129,"E-Bars",902,797,24,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,130,Bars E6,902,827,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,131,130,129,0,0,0,0,0,64,0,-1--1--1,,1|(902,819)|
+10,132,"Bars E6 >3mo-Initial",898,863,44,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,133,132,129,0,0,0,0,0,64,0,-1--1--1,,1|(899,832)|
+10,134,"H-Bars",1101,796,29,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,135,Bars E7,1101,826,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,136,135,134,0,0,0,0,0,64,0,-1--1--1,,1|(1101,818)|
+10,137,Bars E8,1101,855,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,138,137,134,0,0,0,0,0,64,0,-1--1--1,,1|(1101,832)|
+10,139,"Bars E9-Initial",1101,887,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,140,139,134,0,0,0,0,0,64,0,-1--1--1,,1|(1101,848)|
+10,141,"G-Bars",1003,797,30,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,142,Bars E7,1003,827,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,143,142,141,0,0,0,0,0,64,0,-1--1--1,,1|(1003,819)|
+10,144,Bars E8,1003,858,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,145,144,141,0,0,0,0,0,64,0,-1--1--1,,1|(1003,834)|
+10,146,"Exp-C-Bars",698,942,40,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,147,"Exp-E-Bars",903,941,39,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,148,"Exp-H-Bars",1102,940,40,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|10||128-0-128
+10,149,"Bars E4-Final",698,972,53,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,150,149,146,0,0,0,0,0,64,0,-1--1--1,,1|(698,964)|
+10,151,Bars E6,903,971,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,152,151,147,0,0,0,0,0,64,0,-1--1--1,,1|(903,963)|
+10,153,"Bars E6 >3mo-Final",903,1019,43,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,154,153,147,0,0,0,0,0,64,0,-1--1--1,,1|(903,983)|
+10,155,Bars E7,1102,970,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,156,155,148,0,0,0,0,0,64,0,-1--1--1,,1|(1102,962)|
+10,157,Bars E8,1104,997,36,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,158,157,148,0,0,0,0,0,64,0,-1--1--1,,1|(1103,975)|
+10,159,"Bars E9-Final",1103,1035,53,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,160,159,148,0,0,0,0,0,64,0,-1--1--1,,1|(1102,994)|
+10,161,Total Pts in Psych,997,195,41,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+10,162,Total Pts at Final Time,825,276,54,19,8,3,0,0,0,0,0,0
+1,163,161,162,0,0,0,0,0,128,0,-1--1--1,,1|(917,232)|
+10,164,FINAL TIME,1004,246,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,165,164,162,0,0,0,0,0,64,0,-1--1--1,,1|(920,259)|
+10,166,Time,907,196,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,167,166,162,0,0,0,0,0,64,0,-1--1--1,,1|(875,227)|
+10,168,Percent Change in Total Patients,701,212,58,19,8,3,0,0,0,0,0,0
+1,169,162,168,0,0,0,0,0,128,0,-1--1--1,,1|(769,247)|
+10,170,"Exp-SankeyScalar",764,489,59,11,8,131,0,0,0,0,0,0
+1,171,1,170,0,0,0,0,0,128,0,-1--1--1,,1|(693,484)|
+1,172,168,170,0,0,0,0,0,128,0,-1--1--1,,1|(731,347)|
+10,173,FINAL TIME,629,357,55,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,174,173,170,0,0,0,0,0,64,0,-1--1--1,,1|(691,418)|
+10,175,Time,703,389,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128
+1,176,175,170,0,0,0,0,0,64,0,-1--1--1,,1|(729,433)|
+10,177,Total Pts at Initial Time,832,128,56,19,8,3,0,0,0,0,0,0
+1,178,177,168,0,0,0,0,0,128,0,-1--1--1,,1|(772,166)|
+1,179,161,177,0,0,0,0,0,128,0,-1--1--1,,1|(923,165)|
+1,180,166,177,0,0,0,0,0,128,0,-1--1--1,,1|(878,170)|
+1,181,166,168,0,0,0,0,0,128,0,-1--1--1,,1|(826,201)|
+1,182,173,168,0,0,0,0,0,128,0,-1--1--1,,1|(659,294)|
+1,183,170,18,0,0,0,0,0,128,0,-1--1--1,,1|(783,448)|
+1,184,170,19,0,0,0,0,0,64,0,-1--1--1,,1|(789,461)|
+1,185,170,20,0,0,0,0,0,64,0,-1--1--1,,1|(800,471)|
+1,186,170,21,0,0,0,0,0,64,0,-1--1--1,,1|(830,478)|
+1,187,170,22,0,0,0,0,0,64,0,-1--1--1,,1|(842,492)|
+1,188,170,23,0,0,0,0,0,64,0,-1--1--1,,1|(852,505)|
+1,189,170,24,0,0,0,0,0,64,0,-1--1--1,,1|(852,515)|
+1,190,170,25,0,0,0,0,0,64,0,-1--1--1,,1|(860,526)|


### PR DESCRIPTION
* Variable names and units updated (even the variables that are only in Vensim)
* Model start time set to -1000 (was only -500 in previous version) -- this should improve stability in equilibrium.  This should not affect the UI at all.
* One question:  I saw two different labels describing the same sub-cohort: "Initiators who Continue," vs "Initiators who Return."  I changed them all to "Initiators who Return."  That label lines up with "Starters who Return," and is less likely to be confused with the initiators who continue in their first three months (ie, the Completers).
