### PR TITLE
Addition of "what is/data ui vs. what if/sim ui" graphic

### DIFF
--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
@@ -100,6 +100,8 @@ b. Develop systems thinking skills and help you to see how several things fit to
 c. Make VA data, initiatives and standards transparent to you.  
 d. Empower you to realize ongoing improvements in team quality of care and team quality of work life.  
 
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
+
 14. To wrap up, let's hone in on our Team Vision
 
 a. You can further wordsmith the Team Vision after the session if you want. 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session02_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session02_say.md
@@ -43,6 +43,7 @@ Hello! I'm __________ and I'm __________ [Co-facilitators introduce themselves].
 ### Let's get started!
 
 ## In-session Exercise (30 minutes): Patient data and team trends
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
 
 1. A word about *MTL* on BISL, the VA's Business Intelligence Service Line:
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session03_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session03_say.md
@@ -43,6 +43,7 @@ Hello! I'm __________ and I'm __________ [Co-facilitators introduce themselves].
 ### Let's get started!
 
 ## In-session Exercise (30 minutes): Team data for simulation
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
 
 1. Let's explore what is in the team data table.
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session04_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session04_say.md
@@ -72,6 +72,7 @@ b. What the topics where team members' perspectives are more divergent?
  + SP shows the effects of measurement based stepped care on patients' symptoms and risk. It allows you to explore the impacts of implementing measurement based care to reduce delays in detecting patients at high risk for suicide, and to improve the quality of care by making better team decisions about when to step patients up to a higher level of care, or step them down to a lower level of care. It is also possible to experiment with team decisions related to new patient wait-times and access, the use of community care, and the impacts of provider overwork and burnout on the quality of care.
 
 4. *[Recap the highest priority need, recommended module, and why.]*
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
 
 ### That's it for _Modeling to learn_ how to prioritize team needs. Next is our Done/Do review.
 
@@ -85,7 +86,7 @@ b. What the topics where team members' perspectives are more divergent?
 
 1. For the next 5 sessions, we will use the _Modeling to Learn_ Simulation User Interface, or sim UI.
 
-2. Remember, all the _MTL_ resources can be accesses from your home base at mtl.how if you forget a specific link. But to go directly to the log-in page for the sim UI, just type mtl.how/sim into your browser.
+2. Remember, all the _MTL_ resources can be accessed from your home base at mtl.how if you forget a specific link. But to go directly to the log-in page for the sim UI, just type mtl.how/sim into your browser.
 
 3. Unlike the data UI, which requires us to use the VA's default browser, Internet Explorer, this UI works better with Chrome. We recommend you use that.
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session05_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session05_say.md
@@ -42,7 +42,7 @@ Hello! I'm __________ and I'm __________ and today we're modeling to learn how t
 ### Let's get started:
 
 # In-session Exercise (30 minutes): Log in; upload and review team data
-
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
 1. In session 3, we used the *MTL* data UI at mtl.how/data to produce our team data file for use in simulation. We want to locate that file now because the first thing we will do when we open the SIM UI is to load that data file we created. So using Internet Explorer, go to mtl.how/data. The team data file for simulation is in the team folder named team_data_sim. 
 
 2. Now, leave that browser window as it is - we'll come back to it in a minute - and open a new window for the sim UI. This works best in Chrome.

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session06_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session06_say.md
@@ -42,6 +42,7 @@ Hello! I'm __________ and I'm __________ [Co-facilitators introduce themselves].
 ### Let's get started:
 
 # In-session Exercise (30 minutes): The Model Diagram and Systems Story
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
 
 ### A. For this session, you should log in to your Individual world at **mtl.how/sim**. That way you'll be able to play along with our scavenger hunt.  
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session07_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session07_say.md
@@ -43,7 +43,7 @@ Hello! I'm __________ and I'm __________ [Co-facilitators introduce themselves].
 ### Let's get started:
 
 ## In-session Exercise (30 minutes): Running a Base Case
-
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">
 1.	Log in to the team world and join the current session.
 
 2.	Enter your question about the Base Case in the *Our Question* text box. Here you'll briefly describe what your team wants to learn from this experiment.


### PR DESCRIPTION
I added the "what is vs. what if"graphic to S1-S7 facilitator guides.
Can you all take a quick look and confirm that the placement makes sense? Or needs to be moved? Or we need extra text surrounding it?

Once this pull request is resolved, I'll replicate our decisions into the Learner SEE guide on mtl.how

<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">