### PR TITLE
Update mtl_session09_see.md

### DIFF
--- a/mtl_facilitate_workgroup/learner_see/mtl_session09_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session09_see.md
@@ -39,7 +39,7 @@ output:
 
 ## Running an Experiment
 
-1.	Login to your team world at mtl.how/sim.
+1.	Login to your team world at [mtl.how/sim](http://mtl.how/sim).
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_1.gif)
 


### PR DESCRIPTION
 I added the url link for the text "mtl.how/sim

The 3rd and 4th gifs will need to be redone (between step 5 and 6, and between steps 8 and 9, respectively), because the experiment panel is different now. Specifically, “Use Team Data for Starting Rate” is now “Prioritize” starting rate vs RVI.

The 5th, 6th, and 7th, gifs could be redone, too, as they show a variable in the control panel of the expanded outputs section that now has a different name.  Maybe this isn’t enough of a change to be worth redoing them.  Specifically, “Use Team Data for Starting Rate” is now “Prioritize”