### PR TITLE
+ file upload instruction, - module-specific info

### DIFF
--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -42,14 +42,13 @@ output:
 
 ## Check the name of your team data file in Explorer
 1. In session 3, we used our team data UI and clicked "Get Team Data Table for Sim UI" to produce our team data for simulation. 
-2. Let's now go back to mtl.how/data in an Internet Explorer window to check the name of our team data file.
-3. The team data file for simulation is in our team folder, in the team_data_sim_ui folder.
+2. Let's now go back to mtl.how/data in an Internet Explorer window and copy (Ctrl+C) the name of that team data file so we can upload it to the Sim UI. It is in our team folder, in the team_data_sim_ui folder.
 
 ![](https://github.com/lzim/teampsd/blob/master/resources/gifs/data_ui_login.gif)
 
 ## Log in to the sim UI in Chrome
 
-4. Log in to the sim UI.
+3. Log in to the sim UI.
 
 + Open a new browser window in Google Chrome and go to mtl.how/sim.
 
@@ -61,8 +60,13 @@ output:
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_login.gif)
 
-5. Orient yourself to the landing page (Team name, navigation icons, player name, welcome text, sections with blue headers).
+## Orient yourself to the landing page
+
+4. Notice the Team name, navigation icons, player name across the top; the welcome text, and the sections with blue headers. 
+
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_exp_maint.gif)
+
+5. In the Team Data Menu Maintenance section on the right, click Add and paste (Ctrl+V) the filename you saved from the data UI into the box.
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_team_data_menu_maint.gif)
 
@@ -70,12 +74,14 @@ output:
 
 + Select the module your team decided to use. 
 
-+ Select the team data you want to use.
++ Select the team data you just uploaded.
 
-  + For CC & MM, you need to select your Learning Mode before hitting Play.  
+  + For the Care Coordination and Medication Management (CC & MM) modules, you need to select your Learning Mode before you click Play.  
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/learning_mode.gif)
 
 + Click Play.
+
+## Orient yourself to the Sim UI Main Page
 
 7. Orient yourself to the Main Page of the sim UI (same information and buttons at top; 3 sections with blue headers - one showing the module and team data selected in its header; the others headed Outputs and Text, Experiments, and Text).
 
@@ -87,17 +93,9 @@ output:
 
 + How do the values in this table strike you? Do they line up with how you think things really are?
 
-9. Find the Team Data Table variables in the system diagram at the left.
+9. Look for the Team Data Table variables in the system diagram at the left.
 
-+ True Missed Appointments %
-
-+ Appointment Supply
-
-+ Return Visit Interval
-
-+ Engagement Duration	
-
-+ New Patient Start Rate (AGG)
+## Log out!
 
 10. Log out of the Sim UI
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -65,9 +65,6 @@ output:
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_exp_maint.gif)
 
-5. In the Team Data Menu Maintenance section on the right, click Add and paste (Ctrl+V) the filename you saved from the data UI into the box.
-
-![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_team_data_menu_maint.gif)
 
 6. Start a New Session
 
@@ -79,8 +76,10 @@ output:
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/learning_mode.gif)
 
 + Click Play.
++ In the Team Data Menu Maintenance section on the right, click Add and paste (Ctrl+V) the filename you saved from the data UI into the box.
 
-## Familiarize yourself with the Sim UI Main Page
+![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_team_data_menu_maint.gif)
+
 
 7. Orient yourself to the Main Page of the sim UI (same information and buttons at top; 3 sections with blue headers - one showing the module and team data selected in its header; the others headed Outputs and Text, Experiments, and Text).
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -60,7 +60,7 @@ output:
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_login.gif)
 
-## Orient yourself to the landing page
+## Check out the landing page
 
 4. Notice the Team name, navigation icons, player name across the top; the welcome text, and the sections with blue headers. 
 
@@ -81,7 +81,7 @@ output:
 
 + Click Play.
 
-## Orient yourself to the Sim UI Main Page
+## Familiarize yourself with the Sim UI Main Page
 
 7. Orient yourself to the Main Page of the sim UI (same information and buttons at top; 3 sections with blue headers - one showing the module and team data selected in its header; the others headed Outputs and Text, Experiments, and Text).
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -42,13 +42,14 @@ output:
 
 ## Check the name of your team data file in Explorer
 1. In session 3, we used our team data UI and clicked "Get Team Data Table for Sim UI" to produce our team data for simulation. 
-2. Let's now go back to mtl.how/data in an Internet Explorer window and copy (Ctrl+C) the name of that team data file so we can upload it to the Sim UI. It is in our team folder, in the team_data_sim_ui folder.
+2. Let's now go back to mtl.how/data in an Internet Explorer window and copy (Ctrl+C) the name of that team data file so we can upload it to the Sim UI. 
+3. The team data file for simulation is in our team folder, in the team_data_sim_ui folder.
 
 ![](https://github.com/lzim/teampsd/blob/master/resources/gifs/data_ui_login.gif)
 
 ## Log in to the sim UI in Chrome
 
-3. Log in to the sim UI.
+4. Log in to the sim UI.
 
 + Open a new browser window in Google Chrome and go to mtl.how/sim.
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -61,9 +61,7 @@ output:
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_login.gif)
 
-## Check out the landing page
-
-4. Notice the Team name, navigation icons, player name across the top; the welcome text, and the sections with blue headers. 
+5. Review the Home page (Team name e, navigation icons, player name; welcome text, and the sections with blue headers).
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_exp_maint.gif)
 


### PR DESCRIPTION
Seemed like there needed to be  a step after 3 that says to copy the filename and a step between 5 & 6 to finish describing how to load the data file. I tried to do as little to change the numbering as possible. If accepted we do have to make the Say file numbers line up.
Could we make the gif about going into the data ui go all the way to pointing to the folder and file?