### PR TITLE
team_tracker_template.md

### DIFF
--- a/issue_templates/team_tracker_template.md
+++ b/issue_templates/team_tracker_template.md
@@ -1,0 +1,207 @@
+## MTL Co-Facilitation Team Tracker Template
+- - - 
+_This checklist will assit co-facilitators with tracking team information accross the 12-session plan._
+
+Note: Each facilitator pair should provide adequate information to best assist future facilitators and provide enough knowledge of team needs and Q/H/F/D.
+
+
+#### Please ensure all information is entered for each session
+
+### Phase 1: PARTNER
+
+**Session 1 Checklist**
+
+- [ ] What is the team's shared vision? 
+- [ ] Specific themes the team brought up while visioning during session 1?
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization.
+
+My GOAL for this session is to document the following themes and differential questions related to the teams need by end of the session.
+
+Specific themes the team brought up when visioning during session 1. _______________________________________
+
+**Session 2 Checklist**
+
+- [ ] What team data trends were observed during session? 
+- [ ] What specific values were noticed within the team data table that relate to the team's highest priority need? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization.
+
+My GOAL for this session is to document the following themes and differential questions related to the teams need by end of the session.
+
+
+**Session 3 Checklist**
+
+- [ ] What data were chosen for the team's context and shared vision to utilize during the "what-if" simulation learning?
+- [ ] What data-related FAQs were prioritized consistent with the team's highest priority need? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is to document the following themes and differential questions related to the teams need by end of the session.
+
+
+**Session 4 Checklist**
+- [ ] What consensus was reached regarding the team's highest priority need? What module was agreed upon for session 5? 
+- [ ] What multiple points of view, variables, and problems were addressed to find a "through line" for the team as a whole?
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is to document the following themes and differential questions related to the teams need by end of the session.
+
+### Phase 2: BUILD
+
+**Session 5 Checklist**
+- [ ] What specific values from the Team Data Table were addressed today? 
+- [ ] What was the team's learning question entered based on the needs assessment and team data? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is that the team will document the following Q/H/F/D by end of the session.
+
+Question: _______________________________________
+
+Hypothesis: _______________________________________
+
+Findings: _______________________________________
+
+Decisions: _______________________________________
+
+**Session 6 Checklist**
+- [ ] What was the team's dynamic hypothesis? 
+- [ ] What causal loop was identified that was most relevant to the team's highest priority need? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is that the team will document the following Q/H/F/D by end of the session.
+
+Question: _______________________________________
+
+Hypothesis: _______________________________________
+
+Findings: _______________________________________
+
+Decisions: _______________________________________
+
+**Session 7**
+- [ ] What findings and decisions were made relative to the base case and dynamic hypothesis? 
+- [ ] What specific value adjustments do you expect to be helpful for the team to experiment with related to their highest priority need?
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is that the team will document the following Q/H/F/D by end of the session.
+
+Question: _______________________________________
+
+Hypothesis: _______________________________________
+
+Findings: _______________________________________
+
+Decisions: _______________________________________
+
+**Session 8**
+- [ ] What alternatives did the team test against their basecase for experiment 1? 
+- [ ] What comparison did they make between their alternative case and basecase? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is that the team will document the following Q/H/F/D by end of the session.
+
+Question: _______________________________________
+
+Hypothesis: _______________________________________
+
+Findings: _______________________________________
+
+Decisions: _______________________________________
+
+**Session 9**
+- [ ] Was CFBT Systems Thinking utilized to interact with the team? How? 
+- [ ] What variables are of particular interest to the team within the output section for experiment 2? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is that the team will document the following Q/H/F/D by end of the session.
+
+Question: _______________________________________
+
+Hypothesis: _______________________________________
+
+Findings: _______________________________________
+
+Decisions: _______________________________________
+
+### Phase 3: APPLY
+
+**Session 10**
+- [ ] Which output charts did you review with the team for experiment 3?
+- [ ] What data observations were made in the session for experiment 3?
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
+
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+
+My GOAL for this session is that the team will document the following Q/H/F/D by end of the session.
+
+Question: _______________________________________
+
+Hypothesis: _______________________________________
+
+Findings: _______________________________________
+
+Decisions: _______________________________________
+
+**Session 11**
+- [ ] How does the team hope to use the previous experiments to guide their clinical decisions? 
+- [ ] What concerns does the team have regarding implementing these changes? 
+- [ ] What were the team's questions? 
+- [ ] What is the team's guiding question and hypotheses?
+- [ ] What are your facilitator needs before next session? 
+
+**Session 12**
+- [ ] What resources did the team find most helpful? 
+- [ ] What were the team's questions? 

--- a/issue_templates/team_tracker_template.md
+++ b/issue_templates/team_tracker_template.md
@@ -50,7 +50,7 @@ My GOAL for this session is to document the following themes and differential qu
 
 NEED: Current working conceptualization of this team's need based on the 4 priorities below? _______________________________________
 
-DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team).
+DIFFERENTIATE: I need to rule in _______________________________________ or rule out _______________________________________ during this session to refine my conceptualization and prepare for the next session (based on growing consensus and capacity building with this team). 
 
 My GOAL for this session is to document the following themes and differential questions related to the teams need by end of the session.
 


### PR DESCRIPTION
Checklist utilized for the team_tracker.
SUPER rough draft. It seems a little lengthy now, but each session has a manageable amount of information. 
Is there a way to only make the checklist populate certain session info when it is moved to that session in the kanban? For example, the content for session 2 would not be populated until the facilitators moved the card to the session 2 column? 
Please provide feedback ASAP so we can move towards use of the tracker. 