### PR TITLE
Update mtl_session07_see.md

### DIFF
--- a/mtl_facilitate_workgroup/learner_see/mtl_session07_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session07_see.md
@@ -25,7 +25,7 @@ output:
 <!-- Do/Done Tables -->
 | <img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" height = "80" width = "80"> **Done** | <img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" height = "90" width = "90"> **Do** |
 | --- | --- | 
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) We logged in to our individual world at mtl.how/sim and entered our question and hypothesis about the Base Case (bc) in the Text section.  ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_text_fields.gif) | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) We will review the _MTL_ sim UI Expanded Outputs and Text section and run a bc simulation.![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_outputs_text_section.gif)| 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) We logged in to our individual world at mtl.how/sim and entered our question and hypothesis about the Base Case (bc) in the Text section.  ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_text_fields.gif) | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) We will review the _MTL_ sim UI Outputs and Text section and run a bc simulation.![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_outputs_text_section.gif)| 
 
 <!-- Learning Objectives Icon --> 
 <img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/learning_objectives.png" height = "90" width = "90" style ="display: inline-block"/> 
@@ -54,13 +54,13 @@ output:
 
 [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_hypothesis.png" height = "50" width = "50" style = "display: inline-block"/>](http://mtl.how/sim) **Our Hypothesis.** *Outline the systems story your team believes will cause the outcomes your team expects to observe.*
 
-4.	Open the Expanded Outputs and Text section and enter text in the boxes to reflect your question and hypothesis about a base case run – one where no new changes are made in your team, and run the simulation out to its 2-year end just using data pulled in from your team data file.
+4.	Expand the Outputs and Text section and enter text in the boxes to reflect your question and hypothesis about a base case run – one where no new changes are made in your team, and run the simulation out to its 2-year end just using data pulled in from your team data file.
 
 ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_outputs_text_section.gif)
 
 5.	Run; then Save (without resetting) the run with the name Base Case.
 
-6.	Review the Current Run Experiment Values in the Control Panel: You should see all variables at Base Case or default values.
+6.	Review the Current Experiment Values in the Control Panel: You should see all variables at Base Case or default values.
 
 7.	Orient yourself to the charts in the Results Dashboard (axes, units, legend, drop-down menu options).
 
@@ -81,4 +81,4 @@ output:
 <!-- Do/Done Tables -->
 | <img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/done.png" height = "80" width = "80"> **Done** | <img src = "https://github.com/lzim/teampsd/blob/master/resources/icons/do.png" height = "90" width = "90"> **Do** |
 | --- | --- | 
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) We entered our Question, Hypothesis, Findings and Decisions for our Base Case (bc) run in the Q/H/F/D boxes of the Text section. ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_text_fields.gif)| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) Log in to mtl.how/sim and explore the results of the bc run in the Results Dashboard of the Expanded Outputs and Text section to prepare for experiment 1. ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_outputs_text_section.gif)|
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) We entered our Question, Hypothesis, Findings and Decisions for our Base Case (bc) run in the Q/H/F/D boxes of the Outputs and Text section. ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_text_fields.gif)| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "75" width = "110">](http://mtl.how/sim) Log in to mtl.how/sim and explore the results of the bc run in the Results Dashboard of the Outputs and Text section to prepare for experiment 1. ![](https://raw.githubusercontent.com/lzim/teampsd/master/resources/gifs/sim_ui_outputs_text_section.gif)|


### PR DESCRIPTION
1. HQ: Please make a call re: whether gifs need to be remade if the only thing changed is the title in blue bar, Outputs -> Outputs and Text. If so, we will point those out when we see them - e.g. here in the DO. If not, we will stop mentioning it 😺 
2. The Step 1 gif only shows typing the mtl.how/sim into a Chrome browser - do we have one that includes logging in?
3. Step 3 gif should mouse over Experiment sliders to show they're set to 0 or bc. It does not need to circle the Team Data Table.
4. I think the Step 4 gif should show only typing in the q/h boxes (not f/d), and should prime those by showing: "What will it mean for our team over the next 2 years if we make no new decisions?" and "If we make no new decisions in our team, we expect to see ___ over the next two years."
5. gifs for some of the remaining steps could be helpful; but are not required and may be more of a visual change (for videos) than desired.