### PR TITLE
Update mtl_session11_see.md

### DIFF
--- a/mtl_facilitate_workgroup/learner_see/mtl_session11_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session11_see.md
@@ -32,7 +32,7 @@ output:
 ## Learning Objectives
 
 1.	Describe what your team has prioritized as decisions to implement in your clinic. 
-2.	Test your team’s plan against your individual and shared, team vision.
+2.	Test your team’s plan against your individual and shared team vision.
 3.	Apply your team’s plan in clinical decisions.
 
 # In-session Exercise (30 minutes): Connect learning and decisions from experiments to original team vision, question, and need
@@ -43,7 +43,7 @@ output:
 
 3.  What hypotheses did we test? 
 
-4.  What insights we will keep in mind as we make clinic decisions?
+4.  What insights will we keep in mind as we make clinic decisions?
 
 5.  What new approaches or targets do we want to focus on?
 


### PR DESCRIPTION
I started to suggest deleting "future" decisions in the Modeling to learn statement; but decided it's actually better to say that then not. Because without it, it implies more that we haven't been making decisions all along. In the session we will focus on *future* decisions.

@staceypark I wonder if the icons at mtl.how can be made to NOT link to the image files? I know the idea is that whenever they may be changed, they'll update automatically. I just worry that it'll make it easy to get sent off-track if people click on them.