### PR TITLE
Rita 2020 03 02 issue 1050 logo size

### DIFF
--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s01_teamvision_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 ## Today we're modeling to learn how to align our team vision.
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say_checklist.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s01_teamvision_title.png"
-     height = "270" width = "590">](#DontLink)
+     height = "175" width = "420">](#DontLink)
 
 # MTL Live Session 01 Facilitator Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session02_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session02_say.md
@@ -13,7 +13,7 @@ output:
   powerpoint_presentation: default
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s02_data_ui_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 02
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session02_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session02_say_checklist.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s02_data_ui_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 02 Facilitator Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session03_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session03_say.md
@@ -13,7 +13,7 @@ output:
   powerpoint_presentation: default
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s03_teamdata_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 03
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session04_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session04_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s04_teamneeds_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 04
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session05_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session05_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s05_teamworld_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # Session 05
 # Today we're modeling to learn how to log in to our team world.

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session06_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session06_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s06_systems_story_title.png"
-     height = "270" width = "590">](#DontLink)   
+     height = "175" width = "420">](#DontLink)   
 
 # MTL Live Session 06
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session06_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session06_say_checklist.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s06_systems_story_title.png"
-     height = "270" width = "590">](#DontLink) 
+     height = "175" width = "420">](#DontLink) 
      
 # MTL Live Session 06 Facilitator Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session07_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session07_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s07_base_case_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 07
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session07_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session07_say_checklist.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s07_base_case_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 07 Facilitator Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session08_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session08_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s08_dynamic_hypothesis_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 
 # MTL Live Session 08
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session08_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session08_say_checklist.md
@@ -13,7 +13,7 @@ output:
   powerpoint_presentation: default
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s08_dynamic_hypothesis_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
      
 # MTL Live Session 08 Facilitator Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session09_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session09_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s09_compare_alternatives_title.png"
-     height = "270" width = "590">](#DontLink)
+     height = "175" width = "420">](#DontLink)
      
 # MTL Live Session 09
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session09_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session09_say_checklist.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s09_compare_alternatives_title.png"
-     height = "270" width = "590">](#DontLink)
+     height = "175" width = "420">](#DontLink)
      
 # MTL Live Session 09 Facilitator Say Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session10_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session10_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s10_systems_thinking_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 # MTL Live Session 10
 
 # Today we're modeling to learn how to use systems thinking.

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session10_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session10_say_checklist.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s10_systems_thinking_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
      
 # MTL Live Session 10 Facilitator Say Checklist
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session11_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session11_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s11_team_decisions_title.png"
-     height = "270" width = "590">](#DontLlink)  
+     height = "175" width = "420">](#DontLlink)  
 
 # MTL Live Session 11
 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session11_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session11_say_checklist.md
@@ -13,7 +13,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s11_team_decisions_title.png"
-     height = "270" width = "590">](#DontLlink)  
+     height = "175" width = "420">](#DontLlink)  
 
 
 # MTL Live Session 11 Facilitator Say Checklist

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session12_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session12_say.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s12_team_plan_title.png"
-height = "270" width = "590">](#DontLink)   
+height = "175" width = "420">](#DontLink)   
 
 
 # MTL Live Session 12

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session12_say_checklist.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session12_say_checklist.md
@@ -12,7 +12,7 @@ output:
   powerpoint_presentation: default
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s12_team_plan_title.png"
-height = "270" width = "590">](#DontLink)   
+height = "175" width = "420">](#DontLink)   
 
 # MTL Live Session 12 Facilitator Say Checklist
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session01_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session01_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s01_teamvision_title.png"
-     height = "270" width = "590">](#DontLink)
+     height = "175" width = "420">](#DontLink)
 
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session02_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session02_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s02_data_ui_title.png"
-     height = "270" width = "590">](#DontLink)  
+    height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 02
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session03_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session03_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s03_teamdata_title.png"
-     height = "270" width = "590">](#DontLink)  
+      height = "175" width = "420">](#DontLink)      
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 03

--- a/mtl_facilitate_workgroup/learner_see/mtl_session04_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session04_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s04_teamneeds_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 04
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s05_teamworld_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 05

--- a/mtl_facilitate_workgroup/learner_see/mtl_session06_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session06_see.md
@@ -15,7 +15,7 @@ output:
 
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s06_systems_story_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 06
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session07_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session07_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s07_base_case_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 07
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session08_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session08_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s08_dynamic_hypothesis_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
      **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 08
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session09_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session09_see.md
@@ -13,7 +13,7 @@ output:
   powerpoint_presentation: default
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s09_compare_alternatives_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 09
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session10_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session10_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s10_systems_thinking_title.png"
-     height = "270" width = "590">](#DontLink)  
+     height = "175" width = "420">](#DontLink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 10

--- a/mtl_facilitate_workgroup/learner_see/mtl_session11_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session11_see.md
@@ -14,7 +14,7 @@ output:
 ---
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s11_team_decisions_title.png"
-     height = "270" width = "590">](#DontLlink)  
+     height = "175" width = "420">](#DontLlink)  
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 11

--- a/mtl_facilitate_workgroup/learner_see/mtl_session12_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session12_see.md
@@ -13,7 +13,7 @@ output:
   powerpoint_presentation: default
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s12_team_plan_title.png"
-height = "270" width = "590">](#DontLink)   
+height = "175" width = "420">](#DontLink)   
 **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 12
 


### PR DESCRIPTION
Hi @staceypark  issue#1050 updated logo size 175*420 across 

1. MTL Blue SEE Guides S1 - S12
2. MTL Blue SAY Guides S1 - S12 and commensurate checklist (S1 - S2 and S6 - S12).
thanks,
Rita

