### PR TITLE
Team data table document

### DIFF
--- a/mtl_facilitate_workgroup/facilitator_say/mtl_2.0/mtl_red_part_2_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_2.0/mtl_red_part_2_say.md
@@ -47,7 +47,7 @@ Hello! I'm __________ and I'm __________.
 **Who would like to "drive" today?** [Recommend the Team Lead]
 
 ### Navigate to the data UI at mtl.how/data. 
-- Remember that this is on the VA's secure SharePoint site, so it works best with Internet Explorer.
+- Remember that this is on the VA's secure SharePoint site, so it works best with Internet Explorer or Edge.
 
 - You'll log in with your VA credentials and you should have all the same permissions here as you do in general for your role in the VA.  
 - Scroll down to your team folder. You should have two folders: data_ui and team_data_table. Click on the "data_ui" folder and open the Excel file. 
@@ -83,7 +83,8 @@ Hello! I'm __________ and I'm __________.
 	- Click on the module drop-down. You can choose any module individually (CC, MM, PSY, AGG, SP), all modules without SP, or all modules including SP. If you are choosing "SP" or "all with SP", make sure to do the previous steps using the **SPReferrals tab**.
 	- Click on "Create Team Data Table".
 	- If you included SP in the module selection, three pop-ups will appear for the three possible care settings (GMH, SMH, PC/PCMHI) to indicate the threshold for minimum gap in patient care required for subsequent visit to be considered a new care episode. *In general for the (GMH or SMH or PC/PCMHI) setting, how long of a gap in patient care is required for the subsequent visit to be considered a new care episode? Set the threshold below in weeks. The default threshold is 39 weeks (9 months).*
-	- The file you generate will have all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	- The team_data_table file you generate will automatically be saved into the team_data_table folder. Regardless of the module selection you make, the team_data_table file will include all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	
 - Navigate back to your team folder at mtl.how/data. Click on the "team_data_table" folder and open the Excel file to find the team data table already produced for you.
  
 ### 1. Select a module for review 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_2.0/mtl_session03_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_2.0/mtl_session03_say.md
@@ -87,7 +87,8 @@ As the graphic illustrates, we use the data UI to look back at team trends over 
 	- Click on the module drop-down. You can choose any module individually (CC, MM, PSY, AGG, SP), all modules without SP, or all modules including SP. If you are choosing "SP" or "all with SP", make sure to do the previous steps using the **SPReferrals tab**.
 	- Click on "Create Team Data Table".
 	- If you included SP in the module selection, three pop-ups will appear for the three possible care settings (GMH, SMH, PC/PCMHI) to indicate the threshold for minimum gap in patient care required for subsequent visit to be considered a new care episode. *In general for the (GMH or SMH or PC/PCMHI) setting, how long of a gap in patient care is required for the subsequent visit to be considered a new care episode? Set the threshold below in weeks. The default threshold is 39 weeks (9 months).*
-	- The file you generate will have all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	- The team_data_table file you generate will automatically be saved into the team_data_table folder. Regardless of the module selection you make, the team_data_table file will include all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	
 - Navigate back to your team folder at mtl.how/data. Click on the "team_data_table" folder and open the Excel file to find the team data table already produced for you.
  
 ### 1. Select a module for review 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_red_part_2_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_red_part_2_say.md
@@ -83,7 +83,8 @@ Hello! I'm __________ and I'm __________.
 	- Click on the module drop-down. You can choose any module individually (CC, MM, PSY, AGG, SP), all modules without SP, or all modules including SP. If you are choosing "SP" or "all with SP", make sure to do the previous steps using the **SPReferrals tab**.
 	- Click on "Create Team Data Table".
 	- If you included SP in the module selection, three pop-ups will appear for the three possible care settings (GMH, SMH, PC/PCMHI) to indicate the threshold for minimum gap in patient care required for subsequent visit to be considered a new care episode. *In general for the (GMH or SMH or PC/PCMHI) setting, how long of a gap in patient care is required for the subsequent visit to be considered a new care episode? Set the threshold below in weeks. The default threshold is 39 weeks (9 months).*
-	- The file you generate will have all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	- The team_data_table file you generate will automatically be saved into the team_data_table folder. Regardless of the module selection you make, the team_data_table file will include all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	
 - Navigate back to your team folder at mtl.how/data. Click on the "team_data_table" folder and open the Excel file to find the team data table already produced for you.
  
 ### 1. Select a module for review 

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session03_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session03_say.md
@@ -87,7 +87,8 @@ As the graphic illustrates, we use the data UI to look back at team trends over 
 	- Click on the module drop-down. You can choose any module individually (CC, MM, PSY, AGG, SP), all modules without SP, or all modules including SP. If you are choosing "SP" or "all with SP", make sure to do the previous steps using the **SPReferrals tab**.
 	- Click on "Create Team Data Table".
 	- If you included SP in the module selection, three pop-ups will appear for the three possible care settings (GMH, SMH, PC/PCMHI) to indicate the threshold for minimum gap in patient care required for subsequent visit to be considered a new care episode. *In general for the (GMH or SMH or PC/PCMHI) setting, how long of a gap in patient care is required for the subsequent visit to be considered a new care episode? Set the threshold below in weeks. The default threshold is 39 weeks (9 months).*
-	- The file you generate will have all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	- The team_data_table file you generate will automatically be saved into the team_data_table folder. Regardless of the module selection you make, the team_data_table file will include all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
+	- 
 - Navigate back to your team folder at mtl.how/data. Click on the "team_data_table" folder and open the Excel file to find the team data table already produced for you.
  
 ### 1. Select a module for review 

--- a/mtl_facilitate_workgroup/learner_see/mtl_2.0/mtl_red_part_1_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_2.0/mtl_red_part_1_see.md
@@ -67,7 +67,6 @@ output:
 ## Your Team Data Folder
 
 ### 3. Scroll to your team folder at the bottom of the page. Open the data_ui folder and open your data_ui file in Excel.
-- If you do not have a data_ui file or need a newly updated one, copy the file in the Master_DataUI folder. This has a master data_UI file that has already been pre-selected for your facility/station.
 
 - Click on the data_ui file. This will show a preview in your Explorer or Edge browser window.
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_2.0/mtl_session02_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_2.0/mtl_session02_see.md
@@ -80,11 +80,6 @@ For *MTL* 1.7 click [here](https://github.com/lzim/mtl/blob/master/release_1.7/m
 - Click on the data_ui file. This will show a preview in your Explorer or Edge browser window.
 - Click on "Edit Workbook" dropdown at the top and then, "Edit in Excel."
 
-
-#### New for _MTL_ 2.0
-- If you do not have a data_ui file or need a newly updated one, copy the file in the Master_DataUI folder. This has a master data_UI file that has already been pre-selected for your facility/station. With this feature, there is also no need to select the "Station" from the "Control" tab anymore in Step 4.
-For *MTL* 1.7 click [here](https://github.com/lzim/mtl/blob/master/release_1.7/mtl_session02_see.md).
-
 ### 4. Go to the ClinicSelection tab. Use columns C-H to select the clinics that make up your team.
 - You can sort and filter by Clinic Name, Division Name, Physical Location, Primary Stopcode, Secondary Stopcode, and Default Provider.
 - Note: This will pull all clinics used in the last two years (including de-activated clinics: denoted by "ZZ"). For de-activated clinics, you can find the date of de-activation in column I.

--- a/mtl_facilitate_workgroup/learner_see/mtl_red_part_1_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_red_part_1_see.md
@@ -67,7 +67,6 @@ output:
 ## Your Team Data Folder
 
 ### 3. Scroll to your team folder at the bottom of the page. Open the data_ui folder and open your data_ui file in Excel.
-- If you do not have a data_ui file or need a newly updated one, copy the file in the Master_DataUI folder. This has a master data_UI file that has already been pre-selected for your facility/station.
 
 - Click on the data_ui file. This will show a preview in your Explorer or Edge browser window.
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session02_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session02_see.md
@@ -80,11 +80,6 @@ For *MTL* 1.7 click [here](https://github.com/lzim/mtl/blob/master/release_1.7/m
 - Click on the data_ui file. This will show a preview in your Explorer or Edge browser window.
 - Click on "Edit Workbook" dropdown at the top and then, "Edit in Excel."
 
-
-#### New for _MTL_ 2.0
-- If you do not have a data_ui file or need a newly updated one, copy the file in the Master_DataUI folder. This has a master data_UI file that has already been pre-selected for your facility/station. With this feature, there is also no need to select the "Station" from the "Control" tab anymore in Step 4.
-For *MTL* 1.7 click [here](https://github.com/lzim/mtl/blob/master/release_1.7/mtl_session02_see.md).
-
 ### 4. Go to the ClinicSelection tab. Use columns C-H to select the clinics that make up your team.
 - You can sort and filter by Clinic Name, Division Name, Physical Location, Primary Stopcode, Secondary Stopcode, and Default Provider.
 - Note: This will pull all clinics used in the last two years (including de-activated clinics: denoted by "ZZ"). For de-activated clinics, you can find the date of de-activation in column I.

--- a/mtl_facilitate_workgroup/learner_see/mtl_session03_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session03_see.md
@@ -67,7 +67,7 @@ output:
 
 - You can now generate a team data table for all the modules without SP (called "All without SP" in the dropdown next to the "Create Team Data Table" button), or all the modules with SP (called "All with SP" in the dropdown next to the "Create Team Data Table" button).
 
-- When you select a team data table option for specific modules, the team_data_table file you generate will have all five module tabs and labels, but will populate 0s for all other parameters that were **not** selected.
+- The team_data_table file you generate will automatically be saved into the team_data_table folder. Regardless of the module selection you make, the team_data_table file will include all five module tabs and labels, but will populate zeroes ("0") for all parameters of  modules that were **not** selected.
 
 	- If you include SP in the module selection, three pop-ups will appear for the three possible care settings (GMH, SMH, PC/PCMHI) to indicate the threshold for minimum gap in patient care required for subsequent visit to be considered a new care episode. *In general for the (GMH or SMH or PC/PCMHI) setting, how long of a gap in patient care is required for the subsequent visit to be considered a new care episode? Set the threshold below in weeks. The default threshold is 39 weeks (9 months).*
 


### PR DESCRIPTION
fixing documentation regarding - 
1. When team_data_table gets produced, it goes into the team_data_table folder
2. regular learners cannot edit the master_dataUI file. They can only open it. So removed from the guides