### PR TITLE
Rita 2020 04 02 logos pre post emails

### DIFF
--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session01.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session01.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 1 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,12 +20,12 @@ output:
 # We decided on our team vision.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session01/s01_learner/mtl_session01_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 |**Selected our Team Vision.** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session02/s02_learner/mtl_session02_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**| 
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/va_team_psd_logo_sq_sm.png" height = "50" width = "75">](mailto:mtl.help@va.gov) **Select our Team Lead and select a standing team meeting time. Email Team PSD at mtl.help@va.gov to clarify the standing team meeting time and ask any questions you have.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session02.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session02.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 2 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -21,12 +21,12 @@ output:
 # We decided on team clinics for the data UI.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session02/s02_learner/mtl_session02_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) **Selected the clinics that make up our team at [mtl.how/data](https://mtl.how/data).** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session03/s03_learner/mtl_session03_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) **Review the HF, Diag, Enc and SP tabs to find a patient (zoom in) and find a team trend (zoom out) at [mtl.how/data](https://mtl.how/data).**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session03.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session03.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 3 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,12 +20,12 @@ output:
 # We decided to find something in the team data table and complete mtl.how/menu.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">  **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session03/s03_learner/mtl_session03_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) **Produced our Team Data for the sim UI.** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session04/s04_learner/mtl_session04_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_menu.png" height = "45" width = "75">](http://mtl.how/menu) **1. Find something in the team data table at [mtl.how/data](https://mtl.how/data). 2. Complete the [mtl.how/menu](https://mtl.how/menu).**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session04.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session04.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 4 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,12 +20,12 @@ output:
 # We decided our _MTL_ module.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session04/s04_learner/mtl_session04_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_menu.png" height = "45" width = "75">](http://mtl.how/menu) **Selected _MTL_ module: either care coordination (CC), medication management (MM), psychotherapy (PSY), suicide prevention (SP) or aggregate (AGG).** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session05/s05_learner/mtl_session05_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to the _MTL_ simulation user interface (sim UI) at [mtl.how/sim](https://mtl.how/sim). Note: Use all lowercase for login info. Use Chrome for the best experience.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session05.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session05.md
@@ -26,7 +26,7 @@ output:
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Uploaded and reviewed our team data in the sim UI Experiments section.** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "75" width = "75"> **Do** |
+<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Check the "i" information in the Model Diagram and Experiments section in the sim UI at [mtl.how/sim](https://mtl.how/sim).**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session05.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session05.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 5 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -21,12 +21,12 @@ output:
 # We decided to review the "i" information at [mtl.how/sim](https://mtl.how/sim).
 
 <!-- Do/Done Tables -->
- <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+ [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session05/s05_learner/mtl_session05_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Uploaded and reviewed our team data in the sim UI Experiments section.** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session06/s06_learner/mtl_session06_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Check the "i" information in the Model Diagram and Experiments section in the sim UI at [mtl.how/sim](https://mtl.how/sim).**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session05.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session05.md
@@ -13,6 +13,7 @@ output:
 ---
 
 
+
 <!-- MTL Logo, HTML img tag -->
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s05_teamworld_title.png"
      height = "175" width = "420">](https://github.com/lzim/mtl/blob/master/blue/session05/s05_learner/mtl_session05_see.md) 
@@ -20,7 +21,7 @@ output:
 # We decided to review the "i" information at [mtl.how/sim](https://mtl.how/sim).
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "65" width = "65"> **Done** | 
+ <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Uploaded and reviewed our team data in the sim UI Experiments section.** 

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session06.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session06.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 6 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH APril 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # We decided to log in to our individual world at [mtl.how/sim](https://mtl.how/sim) and enter question and hypothesis text.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session06/s06_learner/mtl_session06_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Told a systems story using the Model Diagram and entered a question about the Base Case run in the Q/H/F/D boxes of the Text section.** 
@@ -30,7 +30,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.* |
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*|
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session07/s07_learner/mtl_session07_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to your individual world at [mtl.how/sim](https://mtl.how/sim). Use the question we entered during the session and add your own hypothesis about the Base Case run in the Q/H/F/D boxes of the Text section.** |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session07.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session07.md
@@ -30,7 +30,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.* |
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*|
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session08/s08_learner/mtl_session08_see.md)**Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to [mtl.how/sim](https://mtl.how/sim) and explore the results of the Base Case run to prepare for experiment 1.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session07.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session07.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 7 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 26 2020 | RH March 17 2020"
+date: "September 2018 | RH March 26 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # We decided to review team data, bc and team needs (mtl.how/menu results) to select the "what if" experiment for next time.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session07/s07_learner/mtl_session07_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Entered question, hypothesis, findings and decisions for the Base Case run in the Q/H/F/D boxes of the Text section.** 

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session08.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session08.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 8 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # We decided to compare the Base Case and experiment 1 and draft a dynamic hypothesis for experiment 2.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session08/s08_learner/mtl_session08_see.md)  **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Ran experiment 1 and compared results against the Base Case.** |
@@ -30,7 +30,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.*  |
   <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*  |
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session09/s09_learner/mtl_session09_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Explore the Base Case and experiment 1 in your team world at [mtl.how/sim](https://mtl.how/sim). Log into your individual world at [mtl.how/sim](https://mtl.how/sim) and draft a dynamic hypothesis for experiment 2 in the Q/H/F/D boxes in the.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session09.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session09.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 9 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # We decided to run a third experiment on our own in our individual world. 
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session09/s09_learner/mtl_session09_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Ran experiment 2 and used the Control Panel in the Expanded Outputs section to compare bc, exp 1 and exp 2.** 
@@ -30,7 +30,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.*
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?* |
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session10/s10_learner/mtl_session10_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to your individual world at [mtl.how/sim](https://mtl.how/sim) and run a third experiment including text in the Q/H/F/D boxes of the Text section.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session10.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session10.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 10 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -19,7 +19,7 @@ output:
 # We decided to compare bc, exp 1, exp 2 and exp 3 and think about possible decisions or changes the team could make in clinical care.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session10/s10_learner/mtl_session10_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Ran experiment 3 and discussed bc, exp 1, exp 2 and exp 3 using systems thinking skills.** 
@@ -29,7 +29,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.*
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*     |
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session11/s11_learner/mtl_session11_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**| 
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Compare bc, exp 1, exp 2 and exp 3 and think about possible decisions or changes the team could make in clinical care.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session11.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session11.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 11 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 |RH March 17 2020"
+date: "September 2018 | RH March 16 2020 |RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,13 +20,13 @@ output:
 # We decided to make the following changes.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done**  
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session11/s11_learner/mtl_session11_see.md)  **Done**  
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Discussed team learning and prioritized ways to implement it in our clinical care.**| 
 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session12/s12_learner/mtl_session12_see.md)  **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**| 
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Reflect on our Team Vision and our _MTL_ experience to prepare for planning next steps.**  

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session12.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session12.md
@@ -20,7 +20,7 @@ output:
 # We decided on a booster or follow-up assistance plan.
 
 <!-- Do/Done Tables -->
-| <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65"> **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/done.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session12/s12_learner/mtl_session12_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | **We completed _Modeling to Learn_!** 

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session12.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session12.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 12 Post Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default

--- a/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session12.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/post_emails/mtl_live_post_session12.md
@@ -25,7 +25,7 @@ output:
 |**At Our Last Team Meeting**|
 | **We completed _Modeling to Learn_!** 
 
-<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75"> **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/do.png" height = "75" width = "75">](https://mtl.how) **Do** |
 | --- |
 |**Going Forward**
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sm.png" height = "45" width = "75">](http://mtl.how) **Follow the team plan for next steps. Log in to [mtl.how](https://mtl.how) for ongoing release updates and assistance using _MTL_ resources.** |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session01.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session01.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 1 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020|"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # This week we're modeling to learn how to align our team vision.
 
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session01/s01_learner/mtl_session01_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session01/s01_learner/mtl_session01_see.md) **Do** |
 | --- |
 |**At Our Next Team Meeting**|
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/logos/mtl_how_live_sm.png" height = "45" width = "75">](http://mtl.how/live) **1. Log in to mtl.how/live** and **2. Call in to VANTS:** 1-800-767-1750, Code 27379 |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session02.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session02.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 2 Pre Email"
 author: "Team PSD"
-date: "September 2018 | RH March 16 2020 | RH March 17 2020"
+date: "September 2018 | RH March 16 2020 | RH March 17 2020 | RH March 2 2020"
 output: 
   github_document: default
   html_document: default

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session02.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session02.md
@@ -20,13 +20,13 @@ output:
 # This week we're modeling to learn how to check our patient data and team trends.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session01/s01_learner/mtl_session01_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session01/s01_learner/mtl_session01_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 |**Selected a Team Vision** |
 
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session02/s02_learner/mtl_session02_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session02/s02_learner/mtl_session02_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/va_team_psd_logo_sq_sm.png" height = "50" width = "75">](mailto:mtl.help@va.gov) **Select our Team Lead and select a standing team meeting time. Email Team PSD at mtl.help@va.gov to clarify the standing team meeting time and ask any questions you have.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session03.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session03.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 3 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -21,13 +21,13 @@ output:
 
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session02/s02_learner/mtl_session02_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session02/s02_learner/mtl_session02_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) **Selected the clinics that make up our team.** |
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data)  |
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session03/s03_learner/mtl_session03_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session03/s03_learner/mtl_session03_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) **1. Review the HF, Diag, Enc and SP tabs to find a patient (zoom in) and find a team trend (zoom out). 2. Log in to mtl.how/data and find Team data UI and team_data folders.** |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session04.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session04.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 4 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,13 +20,13 @@ output:
 # This week we're modeling to learn how to prioritize team needs.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session03/s03_learner/mtl_session03_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session03/s03_learner/mtl_session03_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_data_sm.png" height = "45" width = "75">](http://mtl.how/data) **Produced Team Data for the sim UI.**|
 
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session04/s04_learner/mtl_session04_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session04/s04_learner/mtl_session04_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_menu.png" height = "45" width = "75">](http://mtl.how/menu) **1. Find something in the team data table. 2. Complete the _MTL_ Menu at https://mtl.how/menu before the team meeting.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session05.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session05.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 5 Pre Email"
 author: "Team PSD"
-date: "Rh Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "Rh Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -21,12 +21,12 @@ output:
 # This week we're modeling to learn how to log in to our team world in the sim UI.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session04/s04_learner/mtl_session04_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session04/s04_learner/mtl_session04_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_menu.png" height = "45" width = "75">](http://mtl.how/menu) **Selected MTL Module: either care coordination (CC), medication management (MM), psychotherapy (PSY), suicide prevention (SP), or aggregate (AGG).** |
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session05/s05_learner/mtl_session05_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session05/s05_learner/mtl_session05_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting on (Include Date and Time here)**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to the _MTL_ sim UI at https://mtl.how/sim. Note: Use all lowercase for login info. Use Chrome for the best experience.** |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session06.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session06.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 6 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,13 +20,13 @@ output:
 # This week we're modeling to learn how to tell a systems story.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session05/s05_learner/mtl_session05_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session05/s05_learner/mtl_session05_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Uploaded and reviewed team data in the sim UI experiments tile.** |
 
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session06/s06_learner/mtl_session06_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session06/s06_learner/mtl_session06_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Check the "i" information available in the sim UI Model Diagram at mtl.how/sim.** |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session07.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session07.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 7 Pre Email"
 author: "Team PSD"
-date: "RH Oct 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # This week we're modeling to learn how to evaluate our Base Case of no new decisions. 
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session06/s06_learner/mtl_session06_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session06/s06_learner/mtl_session06_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Told a systems story using the Model Diagram in the sim UI and entered our question in the Text section.** |
@@ -30,7 +30,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.* |
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*|
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session07/s07_learner/mtl_session07_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session07/s07_learner/mtl_session07_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to our individual world at https://mtl.how/sim. Use the question we entered during the session and add our own hypothesis about the Base Case run in the Text section.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session08.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session08.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 8 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # This week we're modeling to learn how to test a dynamic hypothesis.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session07/s07_learner/mtl_session07_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session07/s07_learner/mtl_session07_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Entered our Question, Hypothesis, Findings and Decisions for the Base Case run.** |
@@ -31,7 +31,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.* |
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*|
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session08/s08_learner/mtl_session08_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session08/s08_learner/mtl_session08_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Log in to mtl.how/sim and explore the results of the Base Case to prepare for experiment 1.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session09.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session09.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 9 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -19,7 +19,7 @@ output:
 
 # This week we're modeling to learn how to compare alternatives.
 
-|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session08/s08_learner/mtl_session08_see.md) **Done** |
+|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session08/s08_learner/mtl_session08_see.md) **Done** |
 | --- |
 |**At Our Last Team Meeting**  | 
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Ran experiment 1 and compared the results to the Base Case.** |
@@ -32,7 +32,7 @@ output:
 [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/>](http://mtl.how/sim) **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*  |
 
 
-|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session09/s09_learner/mtl_session09_see.md) **Do** |
+|[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session09/s09_learner/mtl_session09_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**  |
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Explore the Base Case and experiment 1 results in our team world. Log into your individual world and draft a dynamic hypothesis for experiment 2.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session10.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session10.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 10 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -19,7 +19,7 @@ output:
 # This week we're modeling to learn how to use systems thinking.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session09/s09_learner/mtl_session09_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session09/s09_learner/mtl_session09_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Ran experiment 2 and used the Control Panel of the Expanded Outputs section to compare bc, exp 1, and exp 2.** |
@@ -30,7 +30,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.*
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?* |
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session10/s10_learner/mtl_session10_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session10/s10_learner/mtl_session10_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Run a third experiment on our own in our individual world.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session11.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session11.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 11 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -20,7 +20,7 @@ output:
 # This week we're modeling to learn how to make team decisions.
 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session10/s10_learner/mtl_session10_see.md) **Done** | 
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session10/s10_learner/mtl_session10_see.md) **Done** | 
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Ran experiment 3 and discussed bc, exp 1, exp 2 and exp 3 using systems thinking skills.** |
@@ -31,7 +31,7 @@ output:
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_findings.png" height = "50" width = "50" style = "display: inline-block"/> **Our Findings.** *Describe your team's findings, insights and conclusions from this experiment.*
 <img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/icons/mtl_decisions.png" height = "50" width = "50" style = "display: inline-block"/> **Our Decisions.** *Based on what you learned in this experiment, what changes are you ready to make in your practice?*     |
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session11/s11_learner/mtl_session11_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session11/s11_learner/mtl_session11_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Review and compare bc, exp 1, exp 2 and exp 3 and think about possible decisions or changes the team could make in clinical care.**  |

--- a/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session12.md
+++ b/mtl_facilitate_workgroup/pre_post_emails/pre_emails/mtl_live_pre_session12.md
@@ -1,7 +1,7 @@
 ---
 title: "MTL Session 12 Pre Email"
 author: "Team PSD"
-date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020"
+date: "RH Oct 18 2019 | RH March 16 2020 | RH March 17 2020 | RH April 2 2020"
 output: 
   github_document: default
   html_document: default
@@ -19,13 +19,13 @@ output:
 
 # This week we're modeling to learn how to turn team learning into a team plan. 
 <!-- Do/Done Tables -->
-| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/session11/s11_learner/mtl_session11_see.md) **Done**  
+| [<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_hexagon-check-mark_309690_003F72.png" height = "65" width = "65">](https://github.com/lzim/mtl/blob/master/blue/session11/s11_learner/mtl_session11_see.md) **Done**  
 | --- |
 |**At Our Last Team Meeting**|
 | [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Discussed the team's learning and prioritized ways to implement it in our clinical care.** | 
 
 
-[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/session12/s12_learner/mtl_session12_see.md) **Do** |
+[<img src = "https://raw.githubusercontent.com/lzim/teampsd/hexagon_icons/np_synchronize_778914_003F72.png" height = "75" width = "75">](https://github.com/lzim/mtl/blob/master/blue/session12/s12_learner/mtl_session12_see.md) **Do** |
 | --- |
 |**Before Our Next Team Meeting**|
 |[<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/logos/mtl_how_sim.png" height = "45" width = "75">](http://mtl.how/sim) **Reflect on our Team Vision and our _MTL_ experience to prepare for planning next steps.**  |


### PR DESCRIPTION
@staceypark

Please accept the pull request for #1278 to  Replace Broken Links in Do and Done Logos in Pre and Post Emails
cross reference #1176
branch rita_2020_04_02_logos_pre_post_emails
thanks
