### PR TITLE
see/say_guide_updates

### DIFF
--- a/mtl_facilitate_workgroup/learner_see/mtl_session01_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session01_see.md
@@ -16,7 +16,7 @@ output:
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s01_teamvision_title.png"
      height = "175" width = "420">](#DontLink)
 
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 01
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session02_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session02_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s02_data_ui_title.png"
     height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 02
 
 # Today we're modeling to learn how to check our patient data and team trends.

--- a/mtl_facilitate_workgroup/learner_see/mtl_session03_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session03_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s03_teamdata_title.png"
       height = "175" width = "420">](#DontLink)      
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 03
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session04_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session04_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s04_teamneeds_title.png"
      height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 04
 
 # Today we're modeling to learn how to prioritize team needs.

--- a/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session05_see.md
@@ -14,7 +14,7 @@ output:
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s05_teamworld_title.png"
      height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 05
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session06_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session06_see.md
@@ -16,7 +16,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s06_systems_story_title.png"
      height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 06
 
 # Today we're modeling to learn how to tell a systems story.

--- a/mtl_facilitate_workgroup/learner_see/mtl_session07_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session07_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s07_base_case_title.png"
      height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 07
 
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session08_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session08_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s08_dynamic_hypothesis_title.png"
      height = "175" width = "420">](#DontLink)  
-     **Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+     **Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 08
 
 # Today we're modeling to learn how to test a dynamic hypothesis.

--- a/mtl_facilitate_workgroup/learner_see/mtl_session09_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session09_see.md
@@ -14,7 +14,7 @@ output:
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s09_compare_alternatives_title.png"
      height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 09
 
 # Today we're modeling to learn how to compare alternatives.

--- a/mtl_facilitate_workgroup/learner_see/mtl_session10_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session10_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s10_systems_thinking_title.png"
      height = "175" width = "420">](#DontLink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 10
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session11_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session11_see.md
@@ -15,7 +15,7 @@ output:
 
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s11_team_decisions_title.png"
      height = "175" width = "420">](#DontLlink)  
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 
 # MTL Live Session 11
 

--- a/mtl_facilitate_workgroup/learner_see/mtl_session12_see.md
+++ b/mtl_facilitate_workgroup/learner_see/mtl_session12_see.md
@@ -14,7 +14,7 @@ output:
 ---
 [<img src = "https://github.com/lzim/teampsd/blob/master/resources/title_slides/mtl_s12_team_plan_title.png"
 height = "175" width = "420">](#DontLink)   
-**Disclaimer**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
+**Note**: If you are a self-directed learner, then some of the details in the guides may not apply to you. These guides were developed for facilitated *Modeling to Learn* Live team meetings.
 # MTL Live Session 12
 
 # Today we're modeling to learn how to turn team learning into a team plan.


### PR DESCRIPTION
See(and Say)_guide_updates contain:

- Updating email links from mtl.info to mtl.help
- S2 language from splashpage (1 word) to splash page (2 words)
- S5 language regarding COP and indicating to use VA email if emailing PII/PHI contents to mtl.help
- All See guides: Changing the language for "Disclaimer" into "Note"