### PR TITLE
Update readme.md

### DIFF
--- a/resources/design/videos/readme.md
+++ b/resources/design/videos/readme.md
@@ -1,6 +1,6 @@
 ---
 title: "Participatory Design - Videos"
-author: "Team PSD" - LZ & ELA
+author: "Team PSD - LZ & ELA"
 date: "May 13, 2020"
 release: "Team PSD 2.0"
 output: 
@@ -78,9 +78,10 @@ The Game DVR feature can capture any application’s window.
 #### Record any window on your Mac.
 
 1. **Press Shift-Command-5**. The _Onscreen Controls_ will appear.
-2. Once the _Onscreen Controls_ appear, **click the down arrow** under _Options_, located next to the record button.
-3. Under _Microphone_, **select none** to turn off audio recording.
-4. Under _Options_ in the _Onscreen Controls,_ **adjust the recording window,** setup a _Timer_, and where to _Save To_ your recording.
+2. Once the _Onscreen Controls_ appear, click on one of the buttons with the record circle in the bottom right (4th icon from the left - **Record Entire Screen** or 5th icon from the left - **Record Selected Portion**)
+3. **Click the down arrow** under _Options_, located next to the record button.
+4. Under _Microphone_, **select none** to turn off audio recording.
+5. Under _Options_ in the _Onscreen Controls,_ **adjust the recording window,** setup a _Timer_, and where to _Save To_ your recording.
 
 <img src = "https://github.com/lzim/teampsd/blob/master/resources/design/videos/mac_screencast.png" width = "600"> 
 


### PR DESCRIPTION
hey @erinash and @lzim - I made two updates to the readme.md
1. In the YAML header, each line has to be encompassed by quotes or else the header won't change into the table format. I moved the end-quote to the end of the line.
2. The onscreen controls initially defaults to "capture"  instead of "record", so the "Options" choices doesn't give you microphone choices. I added an extra line of instructions for this. Once you use this function though, it defaults back to your most recent use, which is why you guys didn't need to go through this step probably