### PR TITLE
Converting three .pdf resources into .md files for Bookdown

### DIFF
--- a/resources/cheatsheets/mtl_how_live_cheatsheet.md
+++ b/resources/cheatsheets/mtl_how_live_cheatsheet.md
@@ -1,0 +1,1 @@
+![mtl_how_live_cheatsheet](https://user-images.githubusercontent.com/59668647/87482201-c4504900-c5e5-11ea-8d33-fef8e791876e.png)

--- a/resources/cheatsheets/mtl_how_osf_cheatsheet.md
+++ b/resources/cheatsheets/mtl_how_osf_cheatsheet.md
@@ -1,0 +1,1 @@
+![mtl_how_osf_cheatsheet md](https://user-images.githubusercontent.com/59668647/87482544-79830100-c5e6-11ea-822b-00702565d9bb.png)

--- a/resources/citation/citation.md
+++ b/resources/citation/citation.md
@@ -1,0 +1,1 @@
+![citation md](https://user-images.githubusercontent.com/59668647/87482855-278eab00-c5e7-11ea-9401-4a4d8abe8da9.png)


### PR DESCRIPTION
Added the following files into a .md format to be included in the #1192 TeamPSD 2.0 Manual using Bookdown.
Located in lzim/teampsd/resources/cheatsheets & resources/citation:
1. mtl_how_live_cheatsheet.md 
2. mtl_how_osf_cheatsheet.md
3. citation.md