### PR TITLE
update post-session checklist -outdated platform

### DIFF
--- a/mtl_facilitate_workgroup/checklists/post_meeting_checklist.md
+++ b/mtl_facilitate_workgroup/checklists/post_meeting_checklist.md
@@ -28,7 +28,7 @@ Submit fidelity ratings for the session at [mtl.how/fidelity](https://mtl.how/fi
 
 3. Create issue cards at [mtl.how/issues](https:/mtl.how/issues) to alert co-facilitators of issues they may encounter and to signal support groups of issues to resolve.
 
-4. Add team details on what was covered during the session following the team_tracker checklist on each team card at [mtl.how/team_tracker](https://mtl.how/team_tracker).
+4. Add team details on what was covered during the session in your co-facilitator chat in teams.
 
 5. Team Emails: 1) Done, 2) Do, 3) Decided  
 


### PR DESCRIPTION
remove ref to team tracker; keeping notes on the team in the co-facilitators chat thread in Teams.