### PR TITLE
oct_epic: Update mtl_session01_say.md

### DIFF
--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
@@ -18,7 +18,7 @@ output:
 
 ## Today we're modeling to learn how to align our team vision.
 
-Hello! I'm __________ and I'm __________ [Co-facilitators introduce themselves]. Today we're modeling to learn how to align our team vision.
+Hello! I'm __________ and I'm __________ [Co-facilitators introduce themselves and HQ staff present]. In a minute when we ask for your feedback, we'll ask each of you to introduce yourselves.
 
 Throughout *Modeling to Learn*, we will start each session in our Learner See Guide at MTL.HOW, which is what we're sharing on our screen now. We'll review what was Done prior to the session and what we will Do in the session, as well as the specific MTL resources that we'll be using. 
 
@@ -45,82 +45,93 @@ Our DO for this session is to Launch _Modeling to Learn_ and select a Team Visio
 
 3. Identify a shared team vision for learning from *Modeling to Learn*.
 
-
-
 ### Let's get started!
 
-## In-session Exercise (30 minutes): Team vision
+### 1. The Big Picture (5 minutes)  
 
-+ We learn best when we seek to accomplish things that matter to us. Today we will clarify what we are trying to accomplish together with *Modeling to Learn*. This learning process will be something you commit to because it reflects a key part your own vision for care in this team.
-
- + Identifying a shared purpose can be deeply motivating. We want to identify a shared purpose about what we are trying to achieve as a team participating in *Modeling to Learn*. The team learning goal provides the focus and energy for committing to learning together over the coming weeks. We have limited time, so we want to identify what is most central to team learning goals and connect this to daily team care delivery.
-
-+ Team learning is all about ‘alignment’ and getting people working in sync with one another to meet the needs of our Veteran patients. We will explore “what is” (retrospective data) and vision forward to “what we would like it to be” (future-oriented). 
-
-+ The goal is to move from “my vision” to “our vision” and to shift the paradigm towards how things could be done with shared decision-making. Together, the clinic team lead and facilitation team will explore “What can be done better?” in a way that reflects common team aspirations. 
-
-### 1. Prior Team Learning Prompt (5 minutes)
-
-a. First, we want to set ground rules for our learning sessions. Think of a good learning experience in your team. It can be in a meeting or an informal exchange with a colleague. It can be when you learned a clinic procedure, an idea for treatment with a difficult patient, or when a team member unlocked a mystery of CPRS for you. Try to think of a time when you had an “aha!” Something finally made sense, or you could finally do something you couldn’t before.
-
-b. Jot down on scratch paper what it was that made it a good learning experience. What were the characteristics of the experience? Compile a team list.
-
-+ *Most likely the following are true:*  
-      • The learning was hands-on and experiential.  
-      • The learning connected to the real world.  
-      • The learning experience was personally relevant, interesting, useful, or meaningful to the learner.  
-      • The learner had choices, shared authority, control, and responsibility.  
-      • The learner learned from and taught others.  
-      • The learner had the support he or she needed.   
-      • The learning was individualized. If there were standards for the work, the learner could meet them in his or her own way.  
-      • It was fun or left the learner feeling good.  
-      • The experience helped the learner understand him- or herself.  
-      • The learner experienced success and accomplishment with challenging work.  
-
-### 2. Best Case Scenario (5 minutes)
-
-a. Now let's envision our *Best Case Scenario*. It is important to create a team language for learning; for aligning team decisions when there are roadblocks to consensus. Start by picturing Veteran mental health care in this team as you experience it now. The interactions and communications within the team, in and out of team meetings. The key people you rely on outside the team. The information and data you use to coordinate care plans, and the feelings you associate with it.
-
-b. Now picture the team learning over the next 6 months in a *best case* scenario, where things are happening in the team the way that you would ideally like them to. This is your *dream team* situation.
-
-### 3. Personal Vision (5 minutes)  
-
-+ Think about your Personal Vision for your team:  
-
-  a. What is team communication like?  
-  b. How do team members relate to one another?  
-  c. How is VA data used?  
-  d. How are decisions, plans and changes made?  
-  
-### 4. Review in Team (5 minutes)  
-
-+ Reflecting as a team on those individual visions:  
-
-  a. What stands out to you?  
-  b. Why did we choose these?  
-  c. What makes them so relevant or important to us?  
-  d. Can we address them all (bearing in mind our resources and time)?  
-  e. If not, which would we most like to address (align around), and why?  
-
-### 5. Putting it Together (10 minutes)  
-
-+ Putting it all together, overall *Modeling to Learn* objectives include activities and competencies that:  
-
-  a. Are meaningful for you and align your learning goals with your team.  
-  b. Develop systems thinking skills that help you to see how several things fit together and understand causes that are hard to see without data and modeling resources.  
-  c. Make VA data, initiatives and standards transparent to you.  
-  d. Empower you to realize ongoing improvements in team quality of care and team quality of work life.  
+A. Those were our learning objectives for today. Overall, *Modeling to Learn* drives toward activities and competencies that:  
+  * Are meaningful for you and align your learning goals with your team.  
+  * Develop systems thinking skills that help you to see how several things fit together and understand causes that are hard to see without data and modeling resources.  
+  * Make VA data, initiatives and standards transparent to you.  
+  * Empower you to realize ongoing improvements in team quality of care and team quality of work life.  
 
 [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">](#DontLink)
 
-### 6. Select the Team Vision  
+B. This graphic tells a high-level story about how we're going to do this in *Modeling to learn*:
+  * First, we're going to say From where we are today, let's get a clear picture of *What Is* in our team by looking back at team-specific data from the past two years. 
+  * Then, using simulation models calibrated specifically to our team, let's test our ideas about new decisions we could make in our team and how they would likely change things over the next two years.
+  * The decisions we will be focusing on are *ones that are within your power to make as front-line staff*. You may also get information about limits to the improvement that is possible with the resources and decisions in your control, which could be evidence that could help inform others' decisions.
 
+C. Today what we want to do is develop a Team vision for learning in *Modeling to Learn* over the next 6 months.
+  * We learn best when we seek to accomplish things that matter to us. Today we will clarify what we are trying to accomplish together with *Modeling to Learn*. This learning process will be something you commit to because it reflects a key part your own vision for care in this team.
+  * Identifying a shared purpose can be deeply motivating. We want to identify a shared purpose about what we are trying to achieve as a team participating in *Modeling to Learn*. The team learning goal provides the focus and energy for committing to learning together over the coming weeks. We have limited time, so we want to identify what is most central to team learning goals and connect this to daily team care delivery.
+  * Team learning is all about ‘alignment’ and getting people working in sync with one another to meet the needs of our Veteran patients. We will explore “what is” (retrospective data) and vision forward to “what we would like it to be” (future-oriented). 
+  * The goal is to move from “my vision” to “our vision” and to shift the paradigm towards how things could be done with shared decision-making. Together, the clinic team lead and facilitation team will explore “What can be done better?” in a way that reflects common team aspirations. 
 
-+ To wrap up, let's home in on our Team Vision  
+### 2. Prior Team Learning Prompt (5 minutes)
 
-  a. You can further word-smith the Team Vision after the session if you want.  
-  b. We'll hold this vision up as a reminder of our shared goals to orient our learning throughout the *MTL* program.  
+A. First, we want to think about norms for our learning sessions. Think of a good learning experience in your team. It can be in a meeting or an informal exchange with a colleague. It can be when you learned a clinic procedure, an idea for treatment with a difficult patient, or when a team member unlocked a mystery of CPRS for you. Try to think of a time when you had an “aha!” Something finally made sense, or you could finally do something you couldn’t before.
 
+B. Think about what it was that made it a good learning experience. What were the characteristics of the experience? Very likely you thought of things like these: 
+  * The learning was hands-on and experiential.  
+  * The learning connected to the real world.  
+  * The learning experience was personally relevant, interesting, useful, or meaningful to the learner.  
+  * The learner had choices, shared authority, control, and responsibility.  
+  * The learner learned from and taught others.  
+  * The learner had the support he or she needed.   
+  * The learning was individualized. If there were standards for the work, the learner could meet them in his or her own way.  
+  * It was fun or left the learner feeling good.  
+  * The experience helped the learner understand him- or herself.  
+  * The learner experienced success and accomplishment with challenging work.  
+
+### 3. Best Case Scenario and Personal Vision (10 minutes)
+
+A. Now let's envision our *Best Case Scenario*. It is important to create a team language for learning; for aligning team decisions when there are roadblocks to consensus. Start by picturing Veteran mental health care in this team as you experience it now. The interactions and communications within the team, in and out of team meetings. The key people you rely on outside the team. The information and data you use to coordinate care plans, and the feelings you associate with it.
+
+B. Now picture the team learning over the next 6 months in a *best case* scenario, where things are happening in the team the way that you would ideally like them to. This is your *dream team* situation.
+
+C. Think about your Personal Vision for your team:  
+  * What is team communication like?  
+  * How do team members relate to one another?  
+  * How is VA data used?  
+  * How are decisions, plans and changes made?  
+
+D. One at a time, please introduce yourself and share a word or two about your *personal* dream-team vision. When you've finished, tap someone who hasn't spoken yet to go next.
+  
+### 5. Review and Synthesize to form Team Vision (10 minutes)  
+
+A. Reflecting as a team on those individual visions:  
+  * What stands out to you?  
+  * Why did we choose these?  
+  * What makes them so relevant or important to us?  
+  * Can we address them all (bearing in mind our resources and time)?  
+  * If not, which would we most like to address (align around), and why?  
+
+B. To wrap up, let's home in on our Team Vision  
+  * Would anyone like to offer a word, phrase, acronym, or symbol - anything that might encapsulate what the team would like to align around during *Modeling to Learn*?
+  * You can further word-smith the Team Vision after the session if you want.  
+  * We'll hold this vision up as a reminder of our shared goals to orient our learning throughout the *MTL* program.  
+
+### 6. Decide Team Lead (5 minutes)
+
+A. We will help the team decide on a Team Lead and standing meeting time over the next week or two. The role of the Team Lead is to:
+ * be the main point of contact between the team and *Modeling to Learn* co-facilitators;
+ * help with scheduling *MTL*-related team meetings;
+ * become familiar with *MTL* resources and help team members trouble-shoot - mainly mtl.how/live (Adobe Connect, used for screen-sharing during meetings), mtl.how/data (the data user interface), mtl.how/sim (the simulation user interface); and
+ * provide leadership during *MTL* sessions, encouraging team participation in discussions and serving as computer simulation lead under co-facilitators' guidance.  
+
+B. Ideal characteristics of the Team Lead include
+ * Having strong relationships with fellow team members;
+ * Being organized;
+ * Having basic computer knowledge (some Excel experience is good);
+ * Attention to detail; and
+ * Committment to process improvement and the use of data to improve care.
+
+C. Some considerations for choosing a standing meeting time are
+ * Whether the team works at a central location or is geographically dispersed; 
+ * Clinic schedules; and
+ * Clinicians' availability.
+ 
 
 ### That's it for *Modeling to Learn* how to align our team vision! Next is our Done/Do review.  
 
@@ -133,36 +144,8 @@ b. Now picture the team learning over the next 6 months in a *best case* scenari
 
 ## DO Demo
 
-1. We will help the team decide on a Team Lead and standing meeting time over the next week or two. The role of the Team Lead is to:
+A. The information is above for how to log in to the *Modeling to Learn* dataUI: you simply type mtl.how/data into any browser and navigate through as you are prompted. The gif here shows you the steps. If you have a chance before next time, try logging in and just check out your facility-level data.
 
- + be the main point of contact between the team and *Modeling to Learn* co-facilitators;
-
- + help with scheduling *MTL*-related team meetings;
-  
- + become familiar with *MTL* resources and help team members trouble-shoot - mainly mtl.how/live (Adobe Connect, used for screen-sharing during meetings), mtl.how/data (the data user interface), mtl.how/sim (the simulation user interface); and
-
- + provide leadership during *MTL* sessions, encouraging team participation in discussions and serving as computer simulation lead under co-facilitators' guidance.  
-
-2. Ideal characteristics of the Team Lead include
-
- + Having strong relationships with fellow team members;
-
- + Being organized;
-
- + Having basic computer knowledge (some Excel experience is good);
-
- + Attention to detail; and
-
- + Committment to process improvement and the use of data to improve care.
-
-3. Some considerations for choosing a standing meeting time are
-
- + Whether the team works at a central location or is geographically dispersed; 
- 
- + Clinic schedules; and
- 
- + Clinicians' availability.
- 
-4. All team members will receive a post-session email the week after each session from the *Modeling to Learn* staff, with Done and Do reminders and links to the necessary resources; and another pre-session email the week of the upcoming session.  
+B. All team members will receive a post-session email the week after each session from the *Modeling to Learn* staff, with Done and Do reminders and links to the necessary resources; and another pre-session email the week of the upcoming session.
 
 ## Until next time, thank you for _Modeling to Learn_!

--- a/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
+++ b/mtl_facilitate_workgroup/facilitator_say/mtl_session01_say.md
@@ -49,18 +49,17 @@ Our DO for this session is to Launch _Modeling to Learn_ and select a Team Visio
 
 ### 1. The Big Picture (5 minutes)  
 
-A. Those were our learning objectives for today. Overall, *Modeling to Learn* drives toward activities and competencies that:  
-  * Are meaningful for you and align your learning goals with your team.  
-  * Develop systems thinking skills that help you to see how several things fit together and understand causes that are hard to see without data and modeling resources.  
-  * Make VA data, initiatives and standards transparent to you.  
-  * Empower you to realize ongoing improvements in team quality of care and team quality of work life.  
+A. Overall, *Modeling to Learn* drives toward activities and competencies that are meaningful for you and align with your team's learning goal. *MTL*:
+  * Helps you develop your systems thinking skills - to better see how different factors and processes in your team fit together, and to understand causes that are hard to see without data and modeling resources.  
+  * Makes VA data, initiatives and standards transparent to you; and uses your hyper-local data to let you test decisions you want to consider "in silico" - so you don't have to "experiment" in the real world.
+  * Empowers you to realize ongoing improvements in team quality of care and team quality of work life. It is not about us telling your team what to do; it is up to your team based on your shared vision, your priorities and needs, and your current reality.
 
 [<img src = "https://raw.githubusercontent.com/lzim/teampsd/master/resources/illustrations/data_ui_sim_ui.png">](#DontLink)
 
-B. This graphic tells a high-level story about how we're going to do this in *Modeling to learn*:
-  * First, we're going to say From where we are today, let's get a clear picture of *What Is* in our team by looking back at team-specific data from the past two years. 
-  * Then, using simulation models calibrated specifically to our team, let's test our ideas about new decisions we could make in our team and how they would likely change things over the next two years.
-  * The decisions we will be focusing on are *ones that are within your power to make as front-line staff*. You may also get information about limits to the improvement that is possible with the resources and decisions in your control, which could be evidence that could help inform others' decisions.
+B. This graphic illustrates how *Modeling to learn* uses participatory learning from simulation to help the team get more Veterans to the right care at the right time to meet their needs. 
+  * We use the *MTL* data user interface (UI) to look back at team trends over the past two years and see *what is* in our team now.
+  * Then we use the *MTL* simulation UI to look at team trends 2 years into the future and answer *what if* questions about different decisions the team could make. 
+  * The decisions we will be focusing on throughout *Modeling to LeaRN* are *ones that are within your power to make as front-line staff*. You may also get information about limits to the improvement that is possible with the resources and decisions in your control, which could provide evidence to inform others' decisions.
 
 C. Today what we want to do is develop a Team vision for learning in *Modeling to Learn* over the next 6 months.
   * We learn best when we seek to accomplish things that matter to us. Today we will clarify what we are trying to accomplish together with *Modeling to Learn*. This learning process will be something you commit to because it reflects a key part your own vision for care in this team.


### PR DESCRIPTION
These proposed changes are to address observed needs encountered in prepping and delivering Blue 01 by Jane, Matt, Marcia, Claire, and Debbie:
1. Participants who were not part of co-planning meetings (most of the team members present) wanted more orientation to MTL. The "putting it together" info and diagram at the end of S01 does a good job of that; we propose moving it to earlier in the meeting.
2. Participants asked, who's to say whether we'll be permitted to make these "decisions" we test and learn about? Added two points about that.
3. S01 guide needs to explicitly include learner introductions. We felt it made best sense to do that at the time that we ask for their personal vision input. This ensures that we hear from everyone.
4. Given added length due to the above, we propose truncating the "Prior Team Learning Prompt" to more didactic - with facilitators' discretion to ask for a few popcorn responses.
5. It seems worthwhile to confirm who will be "team lead" during the session when everyone is already together. This reduces the necessity for ad hoc communications and tracking, and the risk of delays in being able to schedule time with them to select data.

IF THESE CHANGES ARE ADOPTED, THEY WILL NECESSITATE CHANGES TO AT LEAST THE FOLLOWING:
* Blue S01 Say Checklist
* Blue S01 See Guide
* Blue post-S01 email