### PR TITLE
Update pre_meeting_checklist.md

### DIFF
--- a/mtl_facilitate_workgroup/checklists/pre_meeting_checklist.md
+++ b/mtl_facilitate_workgroup/checklists/pre_meeting_checklist.md
@@ -1,7 +1,7 @@
 ---
-title: "Modeling to Learn Facilitate Pre-checklist"
+title: "Modeling to Learn Facilitate Pre-Meeting Checklist"
 author: "Team PSD"
-date: "edited by SP, 2019/09/26"
+date: "edited by SP, 2019/09/26"; "JB 2021/04/09"
 output: 
   github_document: default
   html_document: default
@@ -15,21 +15,23 @@ output:
 <img src = "https://github.com/lzim/teampsd/blob/teampsd_style/mtl_logo/mtl_facilitate_sq_sm.png"
      height = "150" width = "250">  
 
-# MTL Facilitate Pre-checklist
+# MTL Facilitate Pre-Meeting Checklist
 
-## Decide who will be the pre/post prep co-facilitator, who will be the live lead facilitator.
+## 1. Decide who will be the Prep Lead and who will be the Live Lead.
+ 
++ Prep Lead: 
 
-## The week before of the meeting 
-### Pre/Post Co-facilitator  - Jenn Lin will send out April 7, 2021**
-1. Send the pre-session team email.
+    a. Open the Team Tracker card for the session at [mtl.how/team_tracker](mtl.how/team_tracker) for team details prepped during intersession prep.
+    
+    b. for a list of relevant 1) platforms and 2) guides/checklists to prep for each session. [*This instruction needs work.*]
 
-## Day of session Prep Checklist (30 minutes)  
-### Pre/Post Co-facilitator
-Check the session_resources card at the top of each session column at [mtl.how/team_tracker](mtl.how/team_tracker) for a list of relevant 1) platforms and 2) guides/checklists to prep for each session.
++ Live Lead:
 
-### Live Lead Facilitator (should be done during the post-session debrief and reviewed during the prep meeting)
-1. Open the [SEE file](https://mtl.how) at mtl.how for learners.
+  a. Open the [SEE file](https://mtl.how) at mtl.how for learners.
+  
+  b. Open the [SAY checklist](https://_____) at mtl.how/blue 
 
-2. Open the [team_tracker checklist](https://mtl.how/team_tracker) at mtl.how/team_tracker for team details prepped during intersession prep.
+## 2. Divide in-session tasks
 
-3. Divvy up in-session tasks (who will do what e.g., cover the do/done, review the hypothesis from last meeting) with specific time stamps between the two co-facilitators and note these decisions on the [team_tracker checklist](https://mtl.how/team_tracker) for that team.
+  + Who will do what e.g., cover the do/done, learning objectives, review the hypothesis from last meeting
+  + Note specific time stamps on the [team_tracker checklist or is it the say checklist?](https://mtl.how/team_tracker)

--- a/mtl_facilitate_workgroup/checklists/pre_session_checklist.md
+++ b/mtl_facilitate_workgroup/checklists/pre_session_checklist.md
@@ -1,5 +1,5 @@
 ---
-title: "Modeling to Learn Facilitate Pre-Meeting Checklist"
+title: "Modeling to Learn Facilitate Pre-Session Checklist"
 author: "Team PSD"
 date: "edited by SP, 2019/09/26"; "JB 2021/04/09"
 output: 
@@ -15,7 +15,7 @@ output:
 <img src = "https://github.com/lzim/teampsd/blob/teampsd_style/mtl_logo/mtl_facilitate_sq_sm.png"
      height = "150" width = "250">  
 
-# MTL Facilitate Pre-Meeting Checklist
+# MTL Facilitate Pre-Session Checklist
 
 ## 1. Decide who will be the Prep Lead and who will be the Live Lead.
  


### PR DESCRIPTION
A simpler, more straightforward checklist would be helpful to guide the 30-minute pre-meeting prep. This is an effort to reduce the hodgepodge of bold and items that aren't related to co-facilitator pre-meeting prep. The actual checklist of steps needs further specificity.